### PR TITLE
disposable pattern, refactor of memory reader, add manifest

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*.cs]
+indent_style = space
+indent_size = 4
+tab_width = 4
+trim_trailing_whitespace = true

--- a/src/DiabloInterface/App.manifest
+++ b/src/DiabloInterface/App.manifest
@@ -1,0 +1,76 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC Manifest Options
+             If you want to change the Windows User Account Control level replace the 
+             requestedExecutionLevel node with one of the following.
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            Specifying requestedExecutionLevel element will disable file and registry virtualization. 
+            Remove this element if your application requires this virtualization for backwards
+            compatibility.
+        -->
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on and is
+           is designed to work with. Uncomment the appropriate elements and Windows will 
+           automatically selected the most compatible environment. -->
+
+      <!-- Windows Vista -->
+      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+
+      <!-- Windows 7 -->
+      <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />-->
+
+      <!-- Windows 8 -->
+      <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />-->
+
+      <!-- Windows 8.1 -->
+      <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
+
+      <!-- Windows 10 -->
+      <!--<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />-->
+
+    </application>
+  </compatibility>
+
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
+  <!--
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+  -->
+
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <!--
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+  -->
+
+</assembly>

--- a/src/DiabloInterface/D2/D2DataReader.cs
+++ b/src/DiabloInterface/D2/D2DataReader.cs
@@ -1,47 +1,32 @@
 ﻿using DiabloInterface.D2.Struct;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 
 namespace DiabloInterface
 {
-    public class D2DataReader
+    public class D2DataReader : IDisposable
     {
-        const int PROCESS_WM_READ = 0x0010;
-
-        [DllImport("kernel32.dll")]
-        public static extern IntPtr OpenProcess(int dwDesiredAccess, bool bInheritHandle, int dwProcessId);
-
-        [DllImport("kernel32.dll")]
-        public static extern bool ReadProcessMemory(int hProcess, int lpBaseAddress, byte[] lpBuffer, int dwSize, ref int lpNumberOfBytesRead);
-
         MainWindow main;
 
-        const string d2ProcessName = "game";
-        const string d2ModuleName = "Game.exe";
+        bool disposed = false;
+
+        const string DIABLO_PROCESS_NAME = "game";
+        const string DIABLO_MODULE_NAME = "Game.exe";
 
         const int QUEST_BUFFER_DIFFICULTY_OFFSET = 128;
         const int QUEST_BUFFER_LENGTH = 96;
 
-        bool processRunning;
-        Process D2Process;
-        IntPtr D2ProcessHandle;
-        IntPtr D2ProcessEntryAddress;
+        ProcessMemoryReader reader;
+        D2MemoryTable memory;
+        D2MemoryTable nextMemoryTable;
 
-        // buffer read stuff
-        byte[] buffer;
-        int nullIndex;
-        int bytesRead = 0;
-
-        Encoding enc;
         short difficulty;
         D2Data.Penalty currentPenalty;
         bool haveReset;
         string tmpName;
-        
+
 
         int[] mask8BitSet = { 128, 64, 32, 16, 8, 4, 2, 1 };
 
@@ -51,121 +36,72 @@ namespace DiabloInterface
         private D2PlayerData plUnitData;
         private D2StatListEx plStats;
 
-        int ADDRESS_CHARACTER;
-
-        int ADDRESS_QUESTS;
-        int[] OFFSETS_QUESTS;
-
-        int ADDRESS_DIFFICULTY;
-        int ADDRESS_AREA;
-
-        #region patch 1.14a adresses
-        // const int ADDRESS_MODE = 0x44C658;
-        // int[] OFFSETS_MODE = new int[] { 0x40, 0x210 };
-        // const int ADDRESS_CHARACTER = 0x00498288;
-        // int[] OFFSETS_CHARACTER = new int[] { 0x174, 0x5c, 0x48, 0x00 };
-
-        // const int ADDRESS_DIFFICULTY = 0x42E1AC;
-        // const int ADDRESS_NAME = 0x82E164;
-        #endregion
-
-        #region patch 1.14b adresses
-        //int ADDRESS_CHARACTER = 0x0039DEFC;
-        //int[] OFFSETS_INVENTORY = new int[] { 0x60 };
-
-        //int ADDRESS_QUESTS = 0x003B8E54;
-        //int[] OFFSETS_QUESTS = new int[] { 0x264, 0x450, 0x20, 0x00 };
-
-        //int ADDRESS_DIFFICULTY = 0x00398694;
-        //int ADDRESS_AREA = 0x0039B1C8;
-        #endregion
-
-        #region patch 1.14c adresses
-        //int ADDRESS_CHARACTER = 0x0039CEFC;
-        //int[] OFFSETS_INVENTORY = new int[] { 0x60 };
-
-        //int ADDRESS_QUESTS = 0x003B7E54;
-        //int[] OFFSETS_QUESTS = new int[] { 0x264, 0x450, 0x20, 0x00 };
-
-        //int ADDRESS_DIFFICULTY = 0x00397694;
-        //int ADDRESS_AREA = 0x0039A1C8;
-        #endregion
-        
-        public T ReadStructByAddress<T>(int address) where T : struct
-        {
-            return ByteArrayToStructure<T>(readBuffer(Marshal.SizeOf(typeof(T)), address));
-        }
-
-        T ByteArrayToStructure<T>(byte[] bytes) where T : struct
-        {
-            GCHandle handle = GCHandle.Alloc(bytes, GCHandleType.Pinned);
-            T stuff = (T)Marshal.PtrToStructure(handle.AddrOfPinnedObject(), typeof(T));
-            handle.Free();
-            return stuff;
-        }
-
-        public D2DataReader (MainWindow main)
+        public D2DataReader(MainWindow main, D2MemoryTable memory)
         {
             this.main = main;
-            enc = Encoding.GetEncoding("UTF-8");
+            this.memory = memory;
+
             player = new D2Player();
-            setD2Version();
         }
 
-        public void setD2Version ( string version = "1.14c" )
+        #region Disposable
+
+        ~D2DataReader()
         {
-            switch (version)
+            Dispose(false);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
             {
-                case "1.14b":
-                    ADDRESS_CHARACTER = 0x0039DEFC;
+                this.disposed = true;
 
-                    ADDRESS_QUESTS = 0x003B8E54;
-                    OFFSETS_QUESTS = new int[] { 0x264, 0x450, 0x20, 0x00 };
-
-                    ADDRESS_DIFFICULTY = 0x00398694;
-                    ADDRESS_AREA = 0x0039B1C8;
-                    break;
-                case "1.14c":
-                default:
-                    ADDRESS_CHARACTER = 0x0039CEFC;
-
-                    ADDRESS_QUESTS = 0x003B7E54;
-                    OFFSETS_QUESTS = new int[] { 0x264, 0x450, 0x20, 0x00 };
-
-                    ADDRESS_DIFFICULTY = 0x00397694;
-                    ADDRESS_AREA = 0x0039A1C8;
-                    break;
+                if (reader != null)
+                {
+                    reader.Dispose();
+                    reader = null;
+                }
             }
         }
+
+        #endregion
+
+        public void SetNextMemoryTable(D2MemoryTable table)
+        {
+            nextMemoryTable = table;
+        }
+
         public bool checkIfD2Running()
         {
+            // If a reader already exists but the process is closed, dispose of the reader.
+            if (reader != null && !reader.IsValid)
+            {
+                reader.Dispose();
+                reader = null;
+            }
+
+            // A reader exists already.
+            if (reader != null)
+                return true;
+
             try
             {
-                Process[] processes = Process.GetProcessesByName(d2ProcessName);
-                if (processes.Length == 0)
-                {
-                    processRunning = false;
-                    return processRunning;
-                }
+                reader = new ProcessMemoryReader(DIABLO_PROCESS_NAME, DIABLO_MODULE_NAME);
 
-                D2Process = processes[0];
-                D2ProcessHandle = OpenProcess(PROCESS_WM_READ, false, D2Process.Id);
-                for (int i = 0; i < D2Process.Modules.Count; i++)
-                {
-                    if (D2Process.Modules[i].ModuleName == d2ModuleName)
-                    {
-                        D2ProcessEntryAddress = D2Process.Modules[i].BaseAddress;
-                        processRunning = true;
-                        break;
-                    }
-                }
-                return processRunning;
-
+                // Process opened successfully.
+                return true;
             }
-            catch
+            catch (ProcessNotFoundException)
             {
-                processRunning = false;
-                return processRunning;
+                // Failed to open process.
+                return false;
             }
         }
 
@@ -186,33 +122,42 @@ namespace DiabloInterface
 
         public void readDataThreadFunc()
         {
-            while (1 == 1)
+            while (!disposed)
             {
                 Thread.Sleep(500);
 
-                if (!processRunning) {
-                    checkIfD2Running();
+                // Block here until we have a valid reader.
+                if (!checkIfD2Running())
                     continue;
+
+                // Memory table change.
+                if (nextMemoryTable != null)
+                {
+                    memory = nextMemoryTable;
+                    nextMemoryTable = null;
                 }
 
                 try
                 {
                     readData();
                 }
-                catch
+                catch (Exception e)
                 {
-                    processRunning = false;
+#if DEBUG
+                    // Print errors to console in debug builds.
+                    Console.WriteLine("Exception: {0}", e);
+#endif
                 }
             }
         }
 
         public void readData()
         {
+            IntPtr characterUnitAddress = reader.ReadAddress32(memory.Address.Character, AddressingMode.Relative);
+            pl = reader.Read<D2Unit>(characterUnitAddress);
+            plUnitData = reader.Read<D2PlayerData>(new IntPtr(pl.pUnitData));
 
-            pl = ReadStructByAddress<D2Unit>(finalAddress(ADDRESS_CHARACTER, new[] { 0x00 }, true));
-            plUnitData = ReadStructByAddress<D2PlayerData>(pl.pUnitData);
-            
-            // get name 
+            // get name
             tmpName = plUnitData.szPlayerName;
             if (tmpName != "" && tmpName != player.name)
             {
@@ -228,7 +173,7 @@ namespace DiabloInterface
             }
 
             // todo: only read difficulty when it could possibly have changed
-            difficulty = readByte(ADDRESS_DIFFICULTY, null, true);
+            difficulty = reader.ReadByte(memory.Address.Difficulty, AddressingMode.Relative);
             if (difficulty < 0 || difficulty > 2 )
             {
                 difficulty = 0;
@@ -244,19 +189,25 @@ namespace DiabloInterface
             // debug window - quests
             if (main.getDebugWindow() != null)
             {
-                OFFSETS_QUESTS[OFFSETS_QUESTS.Length - 1] = QUEST_BUFFER_DIFFICULTY_OFFSET * 0;
-                main.getDebugWindow().setQuestDataNormal(readBuffer(QUEST_BUFFER_LENGTH, ADDRESS_QUESTS, OFFSETS_QUESTS, true));
-                OFFSETS_QUESTS[OFFSETS_QUESTS.Length - 1] = QUEST_BUFFER_DIFFICULTY_OFFSET * 1;
-                main.getDebugWindow().setQuestDataNightmare(readBuffer(QUEST_BUFFER_LENGTH, ADDRESS_QUESTS, OFFSETS_QUESTS, true));
-                OFFSETS_QUESTS[OFFSETS_QUESTS.Length - 1] = QUEST_BUFFER_DIFFICULTY_OFFSET * 2;
-                main.getDebugWindow().setQuestDataHell(readBuffer(QUEST_BUFFER_LENGTH, ADDRESS_QUESTS, OFFSETS_QUESTS, true));
+                IntPtr questDataAddress = IntPtr.Zero;
 
-                main.getDebugWindow().updateItemStats(this, pl);
+                // Well this is becoming a mess to clean up...
+                memory.Offset.Quests[memory.Offset.Quests.Length - 1] = QUEST_BUFFER_DIFFICULTY_OFFSET * 0;
+                questDataAddress = reader.ResolveAddressPath(memory.Address.Quests, memory.Offset.Quests, AddressingMode.Relative);
+                main.getDebugWindow().setQuestDataNormal(reader.Read(questDataAddress, QUEST_BUFFER_LENGTH));
+                memory.Offset.Quests[memory.Offset.Quests.Length - 1] = QUEST_BUFFER_DIFFICULTY_OFFSET * 1;
+                questDataAddress = reader.ResolveAddressPath(memory.Address.Quests, memory.Offset.Quests, AddressingMode.Relative);
+                main.getDebugWindow().setQuestDataNightmare(reader.Read(questDataAddress, QUEST_BUFFER_LENGTH));
+                memory.Offset.Quests[memory.Offset.Quests.Length - 1] = QUEST_BUFFER_DIFFICULTY_OFFSET * 2;
+                questDataAddress = reader.ResolveAddressPath(memory.Address.Quests, memory.Offset.Quests, AddressingMode.Relative);
+                main.getDebugWindow().setQuestDataHell(reader.Read(questDataAddress, QUEST_BUFFER_LENGTH));
+
+                main.getDebugWindow().updateItemStats(reader, pl);
             }
 
-            plStats = ReadStructByAddress<D2StatListEx>(pl.pStatListEx);
+            plStats = reader.Read<D2StatListEx>(new IntPtr(pl.pStatListEx));
 
-            byte[] statsBuffer = readBuffer(plStats.FullStatsCount * 8, plStats.FullStats);
+            byte[] statsBuffer = reader.Read(new IntPtr(plStats.FullStats), plStats.FullStatsCount * 8);
 
             player.fill(readDataDict(statsBuffer), currentPenalty);
             player.mode = (D2Data.Mode)pl.eMode;
@@ -396,15 +347,15 @@ namespace DiabloInterface
 
             if (haveUnreachedItemSplits)
             {
-                D2Inventory inventory = ReadStructByAddress<D2Inventory>(pl.pInventory);
+                D2Inventory inventory = reader.Read<D2Inventory>(new IntPtr(pl.pInventory));
                 // int inventoryAddr = readInt(ADDRESS_CHARACTER, OFFSETS_INVENTORY, true);
-                
+
 
                 // cursor item (item that is "floating" below cursor when dragging or picking up with open inventory)
                 //itemAddress = inventory.pInvOwnerItem; // readInt(inventoryAddr + 0x20); //BitConverter.ToInt32(new byte[4] { inventory[0x20], inventory[0x21], inventory[0x22], inventory[0x23] }, 0);
                 if (inventory.pInvOwnerItem > 0)
                 {
-                    itemsIds.Add(readInt(inventory.pInvOwnerItem + 0x04));
+                    itemsIds.Add(reader.ReadInt32(new IntPtr(inventory.pInvOwnerItem + 0x04)));
                     //Console.WriteLine("type cursor: " + itemType);
                 }
 
@@ -417,9 +368,9 @@ namespace DiabloInterface
                     D2ItemData itemData;
                     do
                     {
-                        item = ReadStructByAddress<D2Unit>(itemAddress);
+                        item = reader.Read<D2Unit>(new IntPtr(itemAddress));
                         itemsIds.Add(item.eClass);
-                        itemData = ReadStructByAddress<D2ItemData>(item.pUnitData);
+                        itemData = reader.Read<D2ItemData>(new IntPtr(item.pUnitData));
                         itemAddress = itemData.pPrevItem;
                     } while (itemAddress > 0);
                 }
@@ -428,13 +379,15 @@ namespace DiabloInterface
 
             if (haveUnreachedAreaSplits)
             {
-                area = readByte(ADDRESS_AREA, null, true);
+                area = reader.ReadByte(memory.Address.Area, AddressingMode.Relative);
             }
 
             if (haveUnreachedQuestSplits)
             {
-                OFFSETS_QUESTS[OFFSETS_QUESTS.Length - 1] = QUEST_BUFFER_DIFFICULTY_OFFSET * difficulty;
-                questBuffer = readBuffer(QUEST_BUFFER_LENGTH, ADDRESS_QUESTS, OFFSETS_QUESTS, true);
+                memory.Offset.Quests[memory.Offset.Quests.Length - 1] = QUEST_BUFFER_DIFFICULTY_OFFSET * difficulty;
+
+                var questBufferAddress = reader.ResolveAddressPath(memory.Address.Quests, memory.Offset.Quests, AddressingMode.Relative);
+                questBuffer = reader.Read(questBufferAddress, QUEST_BUFFER_LENGTH);
             }
 
             foreach (AutoSplit autosplit in main.settings.autosplits)
@@ -471,7 +424,7 @@ namespace DiabloInterface
                         short value = BitConverter.ToInt16(new byte[2] { reverseBits(questBuffer[autosplit.value]), reverseBits(questBuffer[autosplit.value + 1]), }, 0);
                         if (isNthBitSet(value, 1) || isNthBitSet(value, 0))
                         {
-                            // quest finished 
+                            // quest finished
                             autosplit.reached = true;
                             main.triggerAutosplit(player);
                         }
@@ -479,76 +432,6 @@ namespace DiabloInterface
                 }
             }
 
-        }
-
-        private string readString(int length, int address, int[] offsets = null, bool relative = false)
-        {
-            buffer = readBuffer(length, address, offsets, relative);
-            nullIndex = Array.IndexOf(buffer, (byte)0);
-            return enc.GetString(buffer, 0, (nullIndex == -1) ? buffer.Length : nullIndex);
-        }
-
-        private short readByte(int address, int[] offsets = null, bool relative = false)
-        {
-            try
-            {
-                return readBuffer(0x01, address, offsets, relative)[0];
-            }
-            catch
-            {
-                return -1;
-            }
-        }
-
-        private short readShort(int address, int[] offsets = null, bool relative = false)
-        {
-            try
-            {
-                return BitConverter.ToInt16(readBuffer(0x02, address, offsets, relative), 0);
-            }
-            catch
-            {
-                return -1;
-            }
-        }
-
-        private int readInt(int address, int[] offsets = null, bool relative = false)
-        {
-            try
-            {
-                return BitConverter.ToInt32(readBuffer(0x04, address, offsets, relative), 0);
-            }
-            catch
-            {
-                return -1;
-            }
-        }
-
-        private int finalAddress(int pointer, int[] offsets = null, bool relative = false)
-        {
-            if (relative)
-            {
-                pointer = D2ProcessEntryAddress.ToInt32() + pointer;
-            }
-            if (offsets != null)
-            {
-                buffer = new byte[4];
-                for (int i = 0; i < offsets.Length; i++)
-                {
-                    ReadProcessMemory((int)D2ProcessHandle, pointer, buffer, buffer.Length, ref bytesRead);
-                    pointer = BitConverter.ToInt32(buffer, 0) + offsets[i];
-                }
-
-            }
-            return pointer;
-        }
-
-        public byte[] readBuffer(int length, int pointer, int[] offsets = null, bool relative = false)
-        {
-            pointer = finalAddress(pointer, offsets, relative);
-            buffer = new byte[length];
-            ReadProcessMemory((int)D2ProcessHandle, pointer, buffer, buffer.Length, ref bytesRead);
-            return buffer;
         }
     }
 }

--- a/src/DiabloInterface/D2/D2MemoryTable.cs
+++ b/src/DiabloInterface/D2/D2MemoryTable.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace DiabloInterface
+{
+    public class D2MemoryAdressTable
+    {
+        public IntPtr Character;
+        public IntPtr Quests;
+        public IntPtr Difficulty;
+        public IntPtr Area;
+    }
+
+    public class D2MemoryOffsetTable
+    {
+        public int[] Quests;
+    }
+
+    public class D2MemoryTable
+    {
+        public D2MemoryAdressTable Address = new D2MemoryAdressTable();
+        public D2MemoryOffsetTable Offset = new D2MemoryOffsetTable();
+    }
+}

--- a/src/DiabloInterface/DiabloInterface.csproj
+++ b/src/DiabloInterface/DiabloInterface.csproj
@@ -53,6 +53,12 @@
   <PropertyGroup>
     <ApplicationIcon>Resources\Diablo II_101.ico</ApplicationIcon>
   </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>App.manifest</ApplicationManifest>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="InputSimulator">
       <HintPath>lib\InputSimulator.dll</HintPath>
@@ -69,6 +75,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AutoSplit.cs" />
+    <Compile Include="D2\D2MemoryTable.cs" />
     <Compile Include="D2\D2ItemStatCost.cs" />
     <Compile Include="D2\Struct\D2Inventory.cs" />
     <Compile Include="D2\Struct\D2ItemData.cs" />
@@ -102,6 +109,7 @@
     </Compile>
     <Compile Include="D2\D2Level.cs" />
     <Compile Include="KeyManager.cs" />
+    <Compile Include="ProcessMemoryReader.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SettingsHolder.cs" />
@@ -133,6 +141,9 @@
     <EmbeddedResource Include="Gui\SettingsWindow.resx">
       <DependentUpon>SettingsWindow.cs</DependentUpon>
     </EmbeddedResource>
+    <None Include="App.manifest">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/src/DiabloInterface/Gui/DebugWindow.cs
+++ b/src/DiabloInterface/Gui/DebugWindow.cs
@@ -30,7 +30,7 @@ namespace DiabloInterface
                 return myCp;
             }
         }
-        
+
         public DebugWindow()
         {
             InitializeComponent();
@@ -313,9 +313,9 @@ namespace DiabloInterface
 
         }
 
-        public void updateItemStats(D2DataReader r, D2Unit pl)
+        public void updateItemStats(ProcessMemoryReader r, D2Unit pl)
         {
-            D2Inventory inventory = r.ReadStructByAddress<D2Inventory>(pl.pInventory);
+            D2Inventory inventory = r.Read<D2Inventory>(new IntPtr(pl.pInventory));
 
 
             // all the other items
@@ -328,12 +328,12 @@ namespace DiabloInterface
                 D2StatListEx itemStatListEx;
                 do
                 {
-                    item = r.ReadStructByAddress<D2Unit>(itemAddress);
-                    itemData = r.ReadStructByAddress<D2ItemData>(item.pUnitData);
-                    itemStatListEx = r.ReadStructByAddress<D2StatListEx>(item.pStatListEx);
+                    item = r.Read<D2Unit>(new IntPtr(itemAddress));
+                    itemData = r.Read<D2ItemData>(new IntPtr(item.pUnitData));
+                    itemStatListEx = r.Read<D2StatListEx>(new IntPtr(item.pStatListEx));
                     if (itemData.BodyLoc > (int)D2Data.BodyLoc.None && itemData.BodyLoc <= (int)D2Data.BodyLoc.Gloves)
                     {
-                        byte[] statsBuffer = r.readBuffer(itemStatListEx.FullStatsCount * 8, itemStatListEx.FullStats);
+                        byte[] statsBuffer = r.Read(new IntPtr(itemStatListEx.FullStats), itemStatListEx.FullStatsCount * 8);
                         List<D2ItemStatCost> statsList = D2ItemStatCost.getAll();
 
                         Dictionary<int, int> dataDict = new Dictionary<int, int>();

--- a/src/DiabloInterface/ProcessMemoryReader.cs
+++ b/src/DiabloInterface/ProcessMemoryReader.cs
@@ -1,0 +1,276 @@
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace DiabloInterface
+{
+    public enum AddressingMode
+    {
+        Absolute,
+        Relative
+    }
+
+    public class ProcessNotFoundException : Exception
+    {
+        public ProcessNotFoundException(string processName, string moduleName) :
+            base(string.Format("Could not find process {0}[{1}]", processName, moduleName))
+        { }
+    }
+
+    public class ProcessMemoryReadException : Exception
+    {
+        public ProcessMemoryReadException(uint address) :
+            base(string.Format("Failed to read memory at: 0x{0:X}", address))
+        { }
+    }
+
+    public class ProcessMemoryReader : IDisposable
+    {
+        const uint PROCESS_STILL_ACTIVE = 259;
+
+        IntPtr baseAddress;
+        IntPtr processHandle;
+
+        public bool IsValid
+        {
+            get
+            {
+                uint exitCode = 0;
+                if (!GetExitCodeProcess(processHandle, out exitCode))
+                    return false;
+                return exitCode == PROCESS_STILL_ACTIVE;
+            }
+        }
+
+        public ProcessMemoryReader(string processName, string moduleName)
+        {
+            bool foundModule = false;
+            uint foundProcessId = 0;
+            IntPtr foundBaseAddress = IntPtr.Zero;
+
+            Process[] processes = Process.GetProcessesByName(processName);
+
+            foreach (var process in processes) {
+                foreach (ProcessModule module in process.Modules) {
+                    if (module.ModuleName == moduleName) {
+                        foundModule = true;
+                        foundProcessId = (uint)process.Id;
+                        foundBaseAddress = module.BaseAddress;
+                    }
+                }
+            }
+
+            // Throw if the module cannot be found.
+            if (!foundModule) throw new ProcessNotFoundException(processName, moduleName);
+
+            // Open up handle.
+            baseAddress = foundBaseAddress;
+            ProcessAccessFlags flags = ProcessAccessFlags.QueryLimitedInfo | ProcessAccessFlags.MemoryRead;
+            processHandle = OpenProcess(flags, false, foundProcessId);
+
+            // Make sure we succeeded in opening the handle.
+            if (processHandle == IntPtr.Zero) throw new ProcessNotFoundException(processName, moduleName);
+        }
+
+        #region Disposable
+
+        ~ProcessMemoryReader()
+        {
+            Dispose(false);
+        }
+
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (processHandle != IntPtr.Zero) {
+                CloseHandle(processHandle);
+                processHandle = IntPtr.Zero;
+            }
+        }
+
+        #endregion
+
+        #region Reading
+
+        public IntPtr ResolveAddress(IntPtr address, AddressingMode addressingMode = AddressingMode.Absolute)
+        {
+            // Get relative address if wanted.
+            if (addressingMode == AddressingMode.Relative)
+                return new IntPtr((long)baseAddress + (long)address);
+            // Already in absolute form.
+            else return address;
+        }
+
+        public IntPtr ResolveAddressPath(IntPtr baseAddress, int[] pathOffsets, AddressingMode addressing = AddressingMode.Absolute)
+        {
+            if (pathOffsets == null)
+                return baseAddress;
+
+            IntPtr address = baseAddress;
+            foreach (int offset in pathOffsets)
+            {
+                // Read at the current address and then offset.
+                address = ReadAddress32(address, addressing);
+                address = IntPtr.Add(address, offset);
+
+                // Assume all subsequent addressing to be absolute.
+                addressing = AddressingMode.Absolute;
+            }
+
+            return address;
+        }
+
+        public byte[] Read(IntPtr address, int size, AddressingMode addressingMode = AddressingMode.Absolute)
+        {
+            uint bytesRead;
+            byte[] data = new byte[size];
+            address = ResolveAddress(address, addressingMode);
+            bool success = ReadProcessMemory(processHandle, address, data, (uint)data.Length, out bytesRead);
+
+            // Make sure we read successfully.
+            if (!success || bytesRead != (uint)data.Length)
+                throw new ProcessMemoryReadException((uint)address);
+            return data;
+        }
+
+        /// <summary>
+        /// Read a class/struct from process memory.
+        /// </summary>
+        /// <typeparam name="T">The type to read.</typeparam>
+        /// <param name="address">Process memory address of struct.</param>
+        /// <param name="addressingMode">Absolute or relative memory addressing.</param>
+        /// <returns>The deserialized value or null.</returns>
+        public T Read<T>(IntPtr address, AddressingMode addressingMode = AddressingMode.Absolute)
+        {
+            // Read struct memory.
+            byte[] buffer = Read(address, Marshal.SizeOf<T>(), addressingMode);
+
+            // Convert to structure.
+            T data = default(T);
+            GCHandle handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+
+            try {
+                data = Marshal.PtrToStructure<T>(handle.AddrOfPinnedObject());
+            }
+            finally {
+                handle.Free();
+            }
+
+            return data;
+        }
+
+        public byte ReadByte(IntPtr address, AddressingMode addressingMode = AddressingMode.Absolute)
+        {
+            return Read(address, 1, addressingMode)[0];
+        }
+
+        public short ReadInt16(IntPtr address, AddressingMode addressingMode = AddressingMode.Absolute)
+        {
+            var buffer = Read(address, 2, addressingMode);
+            return BitConverter.ToInt16(buffer, 0);
+        }
+
+        public ushort ReadUInt16(IntPtr address, AddressingMode addressingMode = AddressingMode.Absolute)
+        {
+            var buffer = Read(address, 2, addressingMode);
+            return BitConverter.ToUInt16(buffer, 0);
+        }
+
+        public int ReadInt32(IntPtr address, AddressingMode addressingMode = AddressingMode.Absolute)
+        {
+            var buffer = Read(address, 4, addressingMode);
+            return BitConverter.ToInt32(buffer, 0);
+        }
+
+        public uint ReadUInt32(IntPtr address, AddressingMode addressingMode = AddressingMode.Absolute)
+        {
+            var buffer = Read(address, 4, addressingMode);
+            return BitConverter.ToUInt32(buffer, 0);
+        }
+
+        public long ReadInt64(IntPtr address, AddressingMode addressingMode = AddressingMode.Absolute)
+        {
+            var buffer = Read(address, 8, addressingMode);
+            return BitConverter.ToInt64(buffer, 0);
+        }
+
+        public ulong ReadUInt64(IntPtr address, AddressingMode addressingMode = AddressingMode.Absolute)
+        {
+            var buffer = Read(address, 8, addressingMode);
+            return BitConverter.ToUInt64(buffer, 0);
+        }
+
+        public IntPtr ReadAddress32(IntPtr address, AddressingMode addressingMode = AddressingMode.Absolute)
+        {
+            return new IntPtr(ReadUInt32(address, addressingMode));
+        }
+
+        public string ReadNullTerminatedString(IntPtr address, int size, Encoding encoding, AddressingMode addressing = AddressingMode.Absolute)
+        {
+            byte[] buffer = Read(address, size, addressing);
+
+            // Get entire string buffer as string.
+            string value = encoding.GetString(buffer);
+
+            // Find the null terminator and chop the string there.
+            int nullTerminatorIndex = value.IndexOf('\0');
+            if (nullTerminatorIndex >= 0)
+                value = value.Remove(nullTerminatorIndex);
+            return value;
+        }
+
+        #endregion
+
+        #region Kernel32
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        static extern IntPtr OpenProcess([In] ProcessAccessFlags dwDesiredAccess, [In] bool bInheritHandle, [In] uint dwProcessId);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        static extern bool CloseHandle([In] IntPtr hProcess);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        static extern bool ReadProcessMemory([In] IntPtr hProcess, [In] IntPtr lpBaseAddress, [In, Out] byte[] lpBuffer, [In] uint nSize, [Out] out uint lpNumberOfBytesRead);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        static extern bool GetExitCodeProcess([In] IntPtr hProcess, [Out] out uint lpExitCode);
+
+        #endregion
+
+        #region Flags
+
+        [Flags]
+        enum ProcessAccessFlags : uint
+        {
+            AllAccess =
+                CreateProcess | CreateThread | DuplicateHandle | QueryInformation |
+                QueryLimitedInfo | SetInformation | SetQuota | SuspendResume | Terminate |
+                MemoryOperation | MemoryRead | MemoryWrite | Synchronize,
+            CreateProcess = 0x0080,
+            CreateThread = 0x0002,
+            DuplicateHandle = 0x0040,
+            QueryInformation = 0x0400,
+            QueryLimitedInfo = 0x1000,
+            SetInformation = 0x0200,
+            SetQuota = 0x0100,
+            SuspendResume = 0x0800,
+            Terminate = 0x0001,
+            MemoryOperation = 0x0008,   // PROCESS_VM_OPERATION
+            MemoryRead = 0x0010,        // PROCESS_VM_READ
+            MemoryWrite = 0x0020,       // PROCESS_VM_WRITE
+            Synchronize = 0x00100000
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Implements the disposable pattern so we don't leak any handles, previously CloseHandle(...) was not called after getting a handle from OpenProcess(...).

Added a manifest file so the program automatically requests admin rights.

Refactored code for reading process memory into its own class.