### PR TITLE
Resolve #15, different rune settings for char/difficulty

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ The information that is currently shown in the tool are as follows:
 ### Auto-Splits
 The tool is also able to do automatic splits in connection with a split tool like Livesplit. First you need to setup the same hotkey in DiabloInterface as your Start/Split hotkey in split tool. Then you have to setup splits that should be sent to your split tool. The naming and order of splits in DiabloInterface are not relevant, as only a Keypress is sent to the split tool then a split point is reached. There is no timer integrated directly into this tool (yet). Please note that automatic splits will only work if you start a new character while the tool is running.
 
+### Runes
+
+A rune display is available that can track which runes that the runner still needs. The rune list can be configured per character class and difficulty setting. The rune list used is determined by the most specific configuration in the order `Class+Difficulty > Class > Difficulty > Default`.
+
+The tool can't determine if the runner is intending on a normal/nightmare or hell run, therefore the targeted difficulty will have to be selected. Selecing the target difficulty is done by rightclicking the main interface and choosing `Difficulty->[Your Choice]` (defaults to `Normal`).
+
+
 ### DiabloInterface API
 
 DiabloInterface allows programs running on the same computer to query for game information over a named pipe server.

--- a/src/D2Reader/Character.cs
+++ b/src/D2Reader/Character.cs
@@ -1,20 +1,10 @@
-﻿using Zutatensuppe.D2Reader.Struct.Stat;
-using System;
-using System.Collections.Generic;
-
-namespace Zutatensuppe.D2Reader
+﻿namespace Zutatensuppe.D2Reader
 {
-    public enum CharacterClass
-    {
-        // Order as found in charstats.txt
-        Amazon,      // 0
-        Sorceress,   // 1
-        Necromancer, // 2
-        Paladin,     // 3
-        Barbarian,   // 4
-        Druid,       // 5
-        Assassin     // 6
-    }
+    using System;
+    using System.Collections.Generic;
+
+    using Zutatensuppe.D2Reader.Models;
+    using Zutatensuppe.D2Reader.Struct.Stat;
 
     public class Character
     {

--- a/src/D2Reader/D2Reader.csproj
+++ b/src/D2Reader/D2Reader.csproj
@@ -47,6 +47,8 @@
     <Compile Include="GameMemoryAddressTable.cs" />
     <Compile Include="GameMemoryOffsetTable.cs" />
     <Compile Include="GameMemoryTable.cs" />
+    <Compile Include="Models\CharacterClass.cs" />
+    <Compile Include="Models\Rune.cs" />
     <Compile Include="QuestFactory.cs" />
     <Compile Include="GameMemoryTableFactory.cs" />
     <Compile Include="Models\GameDifficulty.cs" />

--- a/src/D2Reader/Models/CharacterClass.cs
+++ b/src/D2Reader/Models/CharacterClass.cs
@@ -1,0 +1,17 @@
+﻿namespace Zutatensuppe.D2Reader.Models
+{
+    using System.Diagnostics.CodeAnalysis;
+
+    [SuppressMessage("ReSharper", "UnusedMember.Global")]
+    public enum CharacterClass
+    {
+        // Order as found in charstats.txt
+        Amazon,      // 0
+        Sorceress,   // 1
+        Necromancer, // 2
+        Paladin,     // 3
+        Barbarian,   // 4
+        Druid,       // 5
+        Assassin     // 6
+    }
+}

--- a/src/D2Reader/Models/Rune.cs
+++ b/src/D2Reader/Models/Rune.cs
@@ -1,0 +1,42 @@
+﻿namespace Zutatensuppe.D2Reader.Models
+{
+    using System.Diagnostics.CodeAnalysis;
+
+    [SuppressMessage("ReSharper", "UnusedMember.Global")]
+    public enum Rune
+    {
+        El,
+        Eld,
+        Tir,
+        Nef,
+        Eth,
+        Ith,
+        Tal,
+        Ral,
+        Ort,
+        Thul,
+        Amn,
+        Sol,
+        Shael,
+        Dol,
+        Hel,
+        Io,
+        Lum,
+        Ko,
+        Fal,
+        Lem,
+        Pul,
+        Um,
+        Mal,
+        Ist,
+        Gul,
+        Vex,
+        Ohm,
+        Lo,
+        Sur,
+        Ber,
+        Jah,
+        Cham,
+        Zod
+    }
+}

--- a/src/DiabloInterface.Business/Services/GameService.cs
+++ b/src/DiabloInterface.Business/Services/GameService.cs
@@ -5,6 +5,7 @@
     using System.Threading;
 
     using Zutatensuppe.D2Reader;
+    using Zutatensuppe.D2Reader.Models;
     using Zutatensuppe.DiabloInterface.Core.Logging;
 
     public class GameService : IGameService, IDisposable
@@ -31,6 +32,8 @@
         {
             Dispose(false);
         }
+
+        public GameDifficulty TargetDifficulty { get; set; } = GameDifficulty.Normal;
 
         public event EventHandler<CharacterCreatedEventArgs> CharacterCreated;
 

--- a/src/DiabloInterface.Business/Services/IGameService.cs
+++ b/src/DiabloInterface.Business/Services/IGameService.cs
@@ -3,9 +3,15 @@
     using System;
 
     using Zutatensuppe.D2Reader;
+    using Zutatensuppe.D2Reader.Models;
 
     public interface IGameService
     {
+        /// <summary>
+        ///     The targeted (intended) difficulty for a run selected by the player.
+        /// </summary>
+        GameDifficulty TargetDifficulty { get; set; }
+
         /// <summary>
         ///     Occurs when a new character is created at level 1.
         /// </summary>

--- a/src/DiabloInterface.Business/Settings/ApplicationSettings.cs
+++ b/src/DiabloInterface.Business/Settings/ApplicationSettings.cs
@@ -4,6 +4,10 @@
     using System.Drawing;
     using System.Windows.Forms;
 
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+
+    using Zutatensuppe.D2Reader.Models;
     using Zutatensuppe.DiabloInterface.Business.AutoSplits;
 
     public class ApplicationSettings
@@ -20,7 +24,7 @@
         public bool CheckUpdates { get; set; } = true;
         public Keys AutosplitHotkey { get; set; } = Keys.None;
         public List<AutoSplit> Autosplits { get; set; } = new List<AutoSplit>();
-        public List<int> Runes { get; set; } = new List<int>();
+        public IReadOnlyList<ClassRuneSettings> ClassRunes { get; set; } = new List<ClassRuneSettings>();
         public bool DisplayName { get; set; } = true;
         public bool DisplayLevel { get; set; } = true;
         public bool DisplayDeathCounter { get; set; } = true;
@@ -50,5 +54,17 @@
         public Color ColorPoisonRes { get; set; } = Color.YellowGreen;
 
         public Color ColorBackground { get; set; } = Color.Black;
+    }
+
+    public class ClassRuneSettings
+    {
+        [JsonConverter(typeof(StringEnumConverter))]
+        public CharacterClass? Class { get; set; }
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public GameDifficulty? Difficulty { get; set; }
+
+        [JsonProperty(ItemConverterType = typeof(StringEnumConverter))]
+        public IReadOnlyList<Rune> Runes { get; set; } = new List<Rune>();
     }
 }

--- a/src/DiabloInterface.Business/Settings/DefaultLegacySettingsResolver.cs
+++ b/src/DiabloInterface.Business/Settings/DefaultLegacySettingsResolver.cs
@@ -1,7 +1,11 @@
 ﻿namespace Zutatensuppe.DiabloInterface.Business.Settings
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using System.Windows.Forms;
+
+    using Zutatensuppe.D2Reader.Models;
 
     public class DefaultLegacySettingsResolver : ILegacySettingsResolver
     {
@@ -16,6 +20,8 @@
         {
             if (settings == null) throw new ArgumentNullException(nameof(settings));
             if (obj == null) throw new ArgumentNullException(nameof(obj));
+
+            ConvertRuneSettings(settings, obj);
 
             // Already has hotkeys, no need to resolve.
             if (settings.AutosplitHotkey != Keys.None)
@@ -43,8 +49,7 @@
                 }
 
                 // Combine modifiers and key.
-                Keys key = Keys.None;
-                if (Enum.TryParse(keyValue, true, out key))
+                if (Enum.TryParse(keyValue, true, out Keys key))
                 {
                     hotkey |= key;
                 }
@@ -52,6 +57,24 @@
 
             // Assign specified hotkey.
             settings.AutosplitHotkey = hotkey;
+        }
+
+        void ConvertRuneSettings(ApplicationSettings settings, ILegacySettingsObject legacy)
+        {
+            if (!legacy.Contains("Runes")) return;
+
+            List<int> runes = legacy.Values<int>("Runes").ToList();
+            if (runes.Count == 0) return;
+
+            settings.ClassRunes = new List<ClassRuneSettings>
+            {
+                new ClassRuneSettings()
+                {
+                    Class = null,
+                    Difficulty = null,
+                    Runes = runes.Select(runeId => (Rune)runeId).ToList()
+                }
+            };
         }
     }
 }

--- a/src/DiabloInterface.Business/Settings/JsonLegacySettings.cs
+++ b/src/DiabloInterface.Business/Settings/JsonLegacySettings.cs
@@ -7,13 +7,11 @@
 
     public class JsonLegacySettings : ILegacySettingsObject
     {
-        JToken token;
+        readonly JToken token;
 
         public JsonLegacySettings(JToken token)
         {
-            if (token == null) throw new ArgumentNullException(nameof(token));
-
-            this.token = token;
+            this.token = token ?? throw new ArgumentNullException(nameof(token));
         }
 
         public bool Contains(string key)

--- a/src/DiabloInterface.Business/Settings/JsonSettingsReader.cs
+++ b/src/DiabloInterface.Business/Settings/JsonSettingsReader.cs
@@ -9,22 +9,18 @@
 
     public class JsonSettingsReader : ISettingsReader
     {
-        ILegacySettingsResolver resolver;
-        string jsonData;
+        readonly ILegacySettingsResolver resolver;
+        readonly string jsonData;
 
         public JsonSettingsReader(ILegacySettingsResolver resolver, string filename)
         {
-            if (resolver == null) throw new ArgumentNullException(nameof(resolver));
-
-            this.resolver = resolver;
+            this.resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
             jsonData = File.ReadAllText(filename);
         }
 
         public JsonSettingsReader(ILegacySettingsResolver resolver, string filename, Encoding encoding)
         {
-            if (resolver == null) throw new ArgumentNullException(nameof(resolver));
-
-            this.resolver = resolver;
+            this.resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
             jsonData = File.ReadAllText(filename, encoding);
         }
 
@@ -47,8 +43,9 @@
         {
             try
             {
-                var settings = JsonConvert.DeserializeObject<ApplicationSettings>(jsonData);
-                var legacyObject = new JsonLegacySettings(JObject.Parse(jsonData));
+                var data = JObject.Parse(jsonData);
+                var settings = data.ToObject<ApplicationSettings>();
+                var legacyObject = new JsonLegacySettings(data);
                 return resolver.ResolveSettings(settings, legacyObject);
             }
             catch (JsonException)

--- a/src/DiabloInterface.Core/DiabloInterface.Core.csproj
+++ b/src/DiabloInterface.Core/DiabloInterface.Core.csproj
@@ -47,6 +47,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Extensions\DeepCopyExtension.cs" />
+    <Compile Include="Extensions\EnumerableExtensions.cs" />
     <Compile Include="Extensions\EnumFlagExtension.cs" />
     <Compile Include="Logging\ILogger.cs" />
     <Compile Include="Logging\Log4NetLogger.cs" />

--- a/src/DiabloInterface.Core/Extensions/EnumerableExtensions.cs
+++ b/src/DiabloInterface.Core/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,19 @@
+﻿namespace Zutatensuppe.DiabloInterface.Core.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    public static class EnumerableExtensions
+    {
+        public static void ForEach<T>(this IEnumerable<T> items, Action<T> action)
+        {
+            if (items == null) throw new ArgumentNullException(nameof(items));
+            if (action == null) throw new ArgumentNullException(nameof(action));
+
+            foreach (var item in items)
+            {
+                action(item);
+            }
+        }
+    }
+}

--- a/src/DiabloInterface/DiabloInterface.csproj
+++ b/src/DiabloInterface/DiabloInterface.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Framework\NetFrameworkVersion.cs" />
     <Compile Include="Framework\NetFrameworkVersionComparator.cs" />
     <Compile Include="Framework\NetFrameworkVersionExtension.cs" />
+    <Compile Include="Gui\ControlCollectionExtension.cs" />
     <Compile Include="Gui\Controls\AbstractLayout.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/src/DiabloInterface/DiabloInterface.csproj
+++ b/src/DiabloInterface/DiabloInterface.csproj
@@ -109,6 +109,12 @@
     <Compile Include="Gui\Controls\HotkeyControl.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="Gui\Controls\RuneSettingsPage.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="Gui\Controls\RuneSettingsPage.Designer.cs">
+      <DependentUpon>RuneSettingsPage.cs</DependentUpon>
+    </Compile>
     <Compile Include="Gui\Forms\SimpleSaveDialog.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -169,6 +175,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Gui\Controls\AutoSplitTable.resx">
       <DependentUpon>AutoSplitTable.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Gui\Controls\RuneSettingsPage.resx">
+      <DependentUpon>RuneSettingsPage.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Gui\Forms\SimpleSaveDialog.resx">
       <DependentUpon>SimpleSaveDialog.cs</DependentUpon>

--- a/src/DiabloInterface/Gui/ControlCollectionExtension.cs
+++ b/src/DiabloInterface/Gui/ControlCollectionExtension.cs
@@ -1,0 +1,20 @@
+﻿namespace Zutatensuppe.DiabloInterface.Gui
+{
+    using System;
+    using System.Windows.Forms;
+
+    internal static class ControlCollectionExtension
+    {
+        public static void ClearAndDispose(this Control.ControlCollection controls)
+        {
+            if (controls == null) throw new ArgumentNullException(nameof(controls));
+
+            foreach (Control control in controls)
+            {
+                control.Dispose();
+            }
+
+            controls.Clear();
+        }
+    }
+}

--- a/src/DiabloInterface/Gui/Controls/AbstractLayout.cs
+++ b/src/DiabloInterface/Gui/Controls/AbstractLayout.cs
@@ -11,9 +11,10 @@
     using Zutatensuppe.D2Reader.Models;
     using Zutatensuppe.DiabloInterface.Business.Services;
     using Zutatensuppe.DiabloInterface.Business.Settings;
+    using Zutatensuppe.DiabloInterface.Core.Extensions;
     using Zutatensuppe.DiabloInterface.Core.Logging;
 
-    public partial class AbstractLayout : UserControl
+    public abstract partial class AbstractLayout : UserControl
     {
         static readonly ILogger Logger = LogServiceLocator.Get(MethodBase.GetCurrentMethod().DeclaringType);
 
@@ -43,6 +44,8 @@
         protected IEnumerable<FlowLayoutPanel> RunePanels { get; set; }
 
         protected Dictionary<Control, string> DefaultTexts { get; set; }
+
+        protected abstract Panel RuneLayoutPanel { get; }
 
         void InitializeElements()
         {
@@ -122,17 +125,9 @@
             }
         }
 
-        protected virtual void UpdateSettings(ApplicationSettings settings)
-        {
-        }
+        protected abstract void UpdateSettings(ApplicationSettings settings);
 
-        protected virtual void UpdateLabels(Character player, IList<QuestCollection> quests)
-        {
-        }
-
-        protected virtual void UpdateRuneList(ApplicationSettings settings, IReadOnlyList<Rune> runes)
-        {
-        }
+        protected abstract void UpdateLabels(Character player, IList<QuestCollection> quests);
 
         protected void UpdateLabelWidthAlignment(params Label[] labels)
         {
@@ -169,6 +164,17 @@
 
             activeDifficulty = targetDifficulty;
             activeCharacterClass = characterClass;
+        }
+
+        void UpdateRuneList(ApplicationSettings settings, IReadOnlyList<Rune> runes)
+        {
+            var panel = RuneLayoutPanel;
+            if (panel == null) return;
+
+            panel.Controls.ClearAndDispose();
+            panel.Visible = runes?.Count > 0;
+            runes?.ForEach(rune => panel.Controls.Add(
+                new RuneDisplayElement(rune, settings.DisplayRunesHighContrast, false, false)));
         }
 
         /// <summary>

--- a/src/DiabloInterface/Gui/Controls/AbstractLayout.cs
+++ b/src/DiabloInterface/Gui/Controls/AbstractLayout.cs
@@ -195,25 +195,22 @@
 
         void UpdateRuneDisplay(IEnumerable<int> itemIds)
         {
-            foreach (FlowLayoutPanel fp in RunePanels)
+            var panel = RuneLayoutPanel;
+            if (panel == null) return;
+
+            // Count number of items of each type.
+            Dictionary<int, int> itemClassCounts = itemIds
+                .GroupBy(id => id)
+                .ToDictionary(g => g.Key, g => g.Count());
+
+            foreach (RuneDisplayElement runeElement in panel.Controls)
             {
-                if (fp.Controls.Count <= 0)
-                    continue;
+                var itemClassId = (int)runeElement.Rune + 610;
 
-                // Used for keeping track of how many items of each type there is.
-                Dictionary<int, int> itemClassCounts = itemIds
-                    .GroupBy(id => id)
-                    .ToDictionary(g => g.Key, g => g.Count());
-
-                foreach (RuneDisplayElement c in fp.Controls)
+                if (itemClassCounts.ContainsKey(itemClassId) && itemClassCounts[itemClassId] > 0)
                 {
-                    int eClass = (int)c.Rune + 610;
-
-                    if (itemClassCounts.ContainsKey(eClass) && itemClassCounts[eClass] > 0)
-                    {
-                        itemClassCounts[eClass]--;
-                        c.SetHaveRune(true);
-                    }
+                    itemClassCounts[itemClassId]--;
+                    runeElement.SetHaveRune(true);
                 }
             }
         }

--- a/src/DiabloInterface/Gui/Controls/HorizontalLayout.cs
+++ b/src/DiabloInterface/Gui/Controls/HorizontalLayout.cs
@@ -11,7 +11,6 @@
     using Zutatensuppe.D2Reader.Models;
     using Zutatensuppe.DiabloInterface.Business.Services;
     using Zutatensuppe.DiabloInterface.Business.Settings;
-    using Zutatensuppe.DiabloInterface.Core.Extensions;
     using Zutatensuppe.DiabloInterface.Core.Logging;
 
     public partial class HorizontalLayout : AbstractLayout
@@ -32,6 +31,8 @@
             panelRuneDisplayHorizontal.Hide();
             panelRuneDisplayVertical.Hide();
         }
+
+        protected override Panel RuneLayoutPanel => activeRuneLayoutPanel;
 
         void InitializeElements()
         {
@@ -74,11 +75,9 @@
 
         protected override void UpdateSettings(ApplicationSettings settings)
         {
-            base.UpdateSettings(settings);
-
             ApplyLabelSettings(settings);
             ApplyRuneSettings(settings);
-            UpdateLayout(settings);
+            UpdateLayout();
         }
 
         protected override void UpdateLabels(Character player, IList<QuestCollection> quests)
@@ -118,32 +117,14 @@
             labelHellPerc.Text = $@"HE: {completions[2]:0%}";
         }
 
-        protected override void UpdateRuneList(ApplicationSettings settings, IReadOnlyList<Rune> runes)
+        void UpdateLayout()
         {
-            if (activeRuneLayoutPanel == null) return;
-
-            activeRuneLayoutPanel.Controls.Clear();
-            if (runes == null)
-            {
-                activeRuneLayoutPanel.Visible = false;
-            }
-            else
-            {
-                activeRuneLayoutPanel.Visible = runes.Count > 0;
-                runes.ForEach(rune => activeRuneLayoutPanel.Controls.Add(
-                    new RuneDisplayElement(rune, settings.DisplayRunesHighContrast, false, false)));
-            }
-        }
-
-        void UpdateLayout(ApplicationSettings settings)
-        {
-            int padding = 0;
             // Calculate maximum sizes that the labels can possible get.
             Size nameSize = TextRenderer.MeasureText(new string('W', 15), nameLabel.Font, Size.Empty, TextFormatFlags.SingleLine);
 
             // base stats have 3 char label (STR, VIT, ect.) and realistically a max value < 500 (lvl 99*5 + alkor quest... items can increase this tho)
             // we will assume the "longest" string is DEX: 499 (most likely dex or ene will be longest str.)
-            padding = (panelAdvancedStats.Visible || panelResistances.Visible) ? 8 : 0;
+            var padding = (panelAdvancedStats.Visible || panelResistances.Visible) ? 8 : 0;
             Size statSize = TextRenderer.MeasureText("DEX: 499", strLabel.Font, Size.Empty, TextFormatFlags.SingleLine);
             Size basePanelSize = new Size(statSize.Width + padding, statSize.Height * panelBaseStats.RowCount);
 
@@ -175,7 +156,7 @@
                 + ((count < 3 && panelDiffPercentages.Visible) ? panelDiffPercentages.Width : 0)
             ;
 
-            float ratio = (float)nameSize.Width / (float)statsWidth;
+            float ratio = nameSize.Width / (float)statsWidth;
 
             if (ratio > 1.0f)
             {

--- a/src/DiabloInterface/Gui/Controls/HorizontalLayout.cs
+++ b/src/DiabloInterface/Gui/Controls/HorizontalLayout.cs
@@ -122,10 +122,17 @@
         {
             if (activeRuneLayoutPanel == null) return;
 
-            activeRuneLayoutPanel.Visible = runes.Count > 0;
             activeRuneLayoutPanel.Controls.Clear();
-            runes.ForEach(rune => activeRuneLayoutPanel.Controls.Add(
-                new RuneDisplayElement(rune, settings.DisplayRunesHighContrast, false, false)));
+            if (runes == null)
+            {
+                activeRuneLayoutPanel.Visible = false;
+            }
+            else
+            {
+                activeRuneLayoutPanel.Visible = runes.Count > 0;
+                runes.ForEach(rune => activeRuneLayoutPanel.Controls.Add(
+                    new RuneDisplayElement(rune, settings.DisplayRunesHighContrast, false, false)));
+            }
         }
 
         void UpdateLayout(ApplicationSettings settings)

--- a/src/DiabloInterface/Gui/Controls/RuneDisplayElement.Designer.cs
+++ b/src/DiabloInterface/Gui/Controls/RuneDisplayElement.Designer.cs
@@ -41,7 +41,7 @@
             this.btnRemove.TabIndex = 0;
             this.btnRemove.Text = "X";
             this.btnRemove.UseVisualStyleBackColor = true;
-            this.btnRemove.Click += new System.EventHandler(this.btnRemove_Click);
+            this.btnRemove.Click += new System.EventHandler(this.RemoveButtonOnClick);
             // 
             // pictureBox1
             // 

--- a/src/DiabloInterface/Gui/Controls/RuneDisplayElement.cs
+++ b/src/DiabloInterface/Gui/Controls/RuneDisplayElement.cs
@@ -1,47 +1,11 @@
-﻿using System;
-using System.Drawing;
-using System.Windows.Forms;
-using System.Reflection;
-using System.Collections.Generic;
-
-namespace Zutatensuppe.DiabloInterface.Gui.Controls
+﻿namespace Zutatensuppe.DiabloInterface.Gui.Controls
 {
-    public enum Rune
-    {
-        El,
-        Eld,
-        Tir,
-        Nef,
-        Eth,
-        Ith,
-        Tal,
-        Ral,
-        Ort,
-        Thul,
-        Amn,
-        Sol,
-        Shael,
-        Dol,
-        Hel,
-        Io,
-        Lum,
-        Ko,
-        Fal,
-        Lem,
-        Pul,
-        Um,
-        Mal,
-        Ist,
-        Gul,
-        Vex,
-        Ohm,
-        Lo,
-        Sur,
-        Ber,
-        Jah,
-        Cham,
-        Zod,
-    };
+    using System;
+    using System.Drawing;
+    using System.Windows.Forms;
+    using System.Collections.Generic;
+
+    using Zutatensuppe.D2Reader.Models;
 
     public class Runeword
     {
@@ -61,26 +25,33 @@ namespace Zutatensuppe.DiabloInterface.Gui.Controls
 
     public partial class RuneDisplayElement : UserControl
     {
-        // size of rune images (width and height are same)
-        private const int RUNE_SIZE = 28;
+        // Size of rune images (width and height are same).
+        const int RuneSize = 28;
         
         public Rune Rune { get; private set; }
 
         private bool haveRune = false;
 
-        private Bitmap image;
-        private Bitmap imageRed;
+        Bitmap image;
+        Bitmap imageRed;
 
         public RuneDisplayElement(Rune rune)
         {
             Initialize(rune);
+
+            Disposed += OnDisposed;
         }
+
         public RuneDisplayElement(Rune rune, bool highContrast, bool removable, bool haveRune)
         {
             Initialize(rune, highContrast, removable, haveRune);
+
+            Disposed += OnDisposed;
         }
 
-        private void Initialize(Rune rune, bool highContrast = false, bool removable = true, bool haveRune = true)
+        public event EventHandler<EventArgs> RemoveButtonClicked; 
+
+        void Initialize(Rune rune, bool highContrast = false, bool removable = true, bool haveRune = true)
         {
             InitializeComponent();
 
@@ -88,30 +59,31 @@ namespace Zutatensuppe.DiabloInterface.Gui.Controls
 
             using (Bitmap sprite = (highContrast ? Properties.Resources.runes_high_contrast : Properties.Resources.runes))
             {
-                image = sprite.Clone(new Rectangle(0, (int)Rune * RUNE_SIZE, RUNE_SIZE, RUNE_SIZE), sprite.PixelFormat);
-                imageRed = sprite.Clone(new Rectangle(RUNE_SIZE, (int)Rune * RUNE_SIZE, RUNE_SIZE, RUNE_SIZE), sprite.PixelFormat);
+                image = sprite.Clone(new Rectangle(0, (int)Rune * RuneSize, RuneSize, RuneSize), sprite.PixelFormat);
+                imageRed = sprite.Clone(new Rectangle(RuneSize, (int)Rune * RuneSize, RuneSize, RuneSize), sprite.PixelFormat);
             }
-            Width = RUNE_SIZE * (removable?2:1); // twice as wide if removable, cause of remove button
+            Width = RuneSize * (removable?2:1); // twice as wide if removable, cause of remove button
 
             SetHaveRune(haveRune);
         }
 
+        void OnDisposed(object sender, EventArgs eventArgs)
+        {
+            pictureBox1.BackgroundImage = null;
+
+            image?.Dispose();
+            imageRed?.Dispose();
+        }
+
         public void SetHaveRune(bool haveRune)
         {
-            if (InvokeRequired)
-            {
-                // Delegate call to UI thread.
-                Invoke((Action)(() => SetHaveRune(haveRune)));
-                return;
-            }
-
             this.haveRune = haveRune;
             pictureBox1.BackgroundImage = (haveRune ? image : imageRed);
         }
 
-        private void btnRemove_Click(object sender, EventArgs e)
+        void RemoveButtonOnClick(object sender, EventArgs e)
         {
-            Parent.Controls.Remove(this);
+            RemoveButtonClicked?.Invoke(this, e);
         }
     }
 }

--- a/src/DiabloInterface/Gui/Controls/RuneSettingsPage.Designer.cs
+++ b/src/DiabloInterface/Gui/Controls/RuneSettingsPage.Designer.cs
@@ -1,0 +1,282 @@
+﻿namespace Zutatensuppe.DiabloInterface.Gui.Controls
+{
+    partial class RuneSettingsPage
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
+            this.classSettingsGroupBox = new System.Windows.Forms.GroupBox();
+            this.deleteSettingsButton = new System.Windows.Forms.Button();
+            this.addSettingsButton = new System.Windows.Forms.Button();
+            this.characterListBox = new System.Windows.Forms.ListBox();
+            this.runesGroupBox = new System.Windows.Forms.GroupBox();
+            this.runeFlowLayout = new System.Windows.Forms.FlowLayoutPanel();
+            this.runeListEditBox = new System.Windows.Forms.GroupBox();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.difficultyComboBox = new System.Windows.Forms.ComboBox();
+            this.characterClassComboBox = new System.Windows.Forms.ComboBox();
+            this.classLabel = new System.Windows.Forms.Label();
+            this.difficultyLabel = new System.Windows.Forms.Label();
+            this.runeComboBox = new System.Windows.Forms.ComboBox();
+            this.runeButton = new System.Windows.Forms.Button();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
+            this.splitContainer1.Panel1.SuspendLayout();
+            this.splitContainer1.Panel2.SuspendLayout();
+            this.splitContainer1.SuspendLayout();
+            this.classSettingsGroupBox.SuspendLayout();
+            this.runesGroupBox.SuspendLayout();
+            this.runeListEditBox.SuspendLayout();
+            this.tableLayoutPanel1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // splitContainer1
+            // 
+            this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainer1.Location = new System.Drawing.Point(0, 0);
+            this.splitContainer1.Name = "splitContainer1";
+            // 
+            // splitContainer1.Panel1
+            // 
+            this.splitContainer1.Panel1.Controls.Add(this.classSettingsGroupBox);
+            this.splitContainer1.Panel1MinSize = 140;
+            // 
+            // splitContainer1.Panel2
+            // 
+            this.splitContainer1.Panel2.Controls.Add(this.runesGroupBox);
+            this.splitContainer1.Panel2.Controls.Add(this.runeListEditBox);
+            this.splitContainer1.Panel2MinSize = 200;
+            this.splitContainer1.Size = new System.Drawing.Size(497, 440);
+            this.splitContainer1.SplitterDistance = 150;
+            this.splitContainer1.TabIndex = 0;
+            // 
+            // classSettingsGroupBox
+            // 
+            this.classSettingsGroupBox.Controls.Add(this.deleteSettingsButton);
+            this.classSettingsGroupBox.Controls.Add(this.addSettingsButton);
+            this.classSettingsGroupBox.Controls.Add(this.characterListBox);
+            this.classSettingsGroupBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.classSettingsGroupBox.Location = new System.Drawing.Point(0, 0);
+            this.classSettingsGroupBox.MinimumSize = new System.Drawing.Size(140, 0);
+            this.classSettingsGroupBox.Name = "classSettingsGroupBox";
+            this.classSettingsGroupBox.Size = new System.Drawing.Size(150, 440);
+            this.classSettingsGroupBox.TabIndex = 0;
+            this.classSettingsGroupBox.TabStop = false;
+            this.classSettingsGroupBox.Text = "Class Settings";
+            // 
+            // deleteSettingsButton
+            // 
+            this.deleteSettingsButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.deleteSettingsButton.Location = new System.Drawing.Point(32, 414);
+            this.deleteSettingsButton.Name = "deleteSettingsButton";
+            this.deleteSettingsButton.Size = new System.Drawing.Size(59, 23);
+            this.deleteSettingsButton.TabIndex = 2;
+            this.deleteSettingsButton.Text = "Remove";
+            this.deleteSettingsButton.UseVisualStyleBackColor = true;
+            this.deleteSettingsButton.Click += new System.EventHandler(this.DeleteSettingsButtonOnClick);
+            // 
+            // addSettingsButton
+            // 
+            this.addSettingsButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.addSettingsButton.Location = new System.Drawing.Point(97, 414);
+            this.addSettingsButton.Name = "addSettingsButton";
+            this.addSettingsButton.Size = new System.Drawing.Size(50, 23);
+            this.addSettingsButton.TabIndex = 1;
+            this.addSettingsButton.Text = "Add";
+            this.addSettingsButton.UseVisualStyleBackColor = true;
+            this.addSettingsButton.Click += new System.EventHandler(this.AddSettingsButtonOnClick);
+            // 
+            // characterListBox
+            // 
+            this.characterListBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.characterListBox.FormattingEnabled = true;
+            this.characterListBox.Location = new System.Drawing.Point(3, 16);
+            this.characterListBox.Name = "characterListBox";
+            this.characterListBox.Size = new System.Drawing.Size(144, 394);
+            this.characterListBox.TabIndex = 0;
+            this.characterListBox.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.CharacterListBoxOnMouseDoubleClick);
+            // 
+            // runesGroupBox
+            // 
+            this.runesGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.runesGroupBox.Controls.Add(this.runeFlowLayout);
+            this.runesGroupBox.Location = new System.Drawing.Point(3, 3);
+            this.runesGroupBox.Name = "runesGroupBox";
+            this.runesGroupBox.Size = new System.Drawing.Size(337, 344);
+            this.runesGroupBox.TabIndex = 0;
+            this.runesGroupBox.TabStop = false;
+            this.runesGroupBox.Text = "Runes";
+            // 
+            // runeFlowLayout
+            // 
+            this.runeFlowLayout.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.runeFlowLayout.Location = new System.Drawing.Point(3, 16);
+            this.runeFlowLayout.Name = "runeFlowLayout";
+            this.runeFlowLayout.Size = new System.Drawing.Size(331, 325);
+            this.runeFlowLayout.TabIndex = 0;
+            // 
+            // runeListEditBox
+            // 
+            this.runeListEditBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.runeListEditBox.Controls.Add(this.tableLayoutPanel1);
+            this.runeListEditBox.Controls.Add(this.runeComboBox);
+            this.runeListEditBox.Controls.Add(this.runeButton);
+            this.runeListEditBox.Location = new System.Drawing.Point(3, 353);
+            this.runeListEditBox.Name = "runeListEditBox";
+            this.runeListEditBox.Size = new System.Drawing.Size(337, 84);
+            this.runeListEditBox.TabIndex = 0;
+            this.runeListEditBox.TabStop = false;
+            this.runeListEditBox.Text = "Edit";
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.tableLayoutPanel1.ColumnCount = 2;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel1.Controls.Add(this.difficultyComboBox, 1, 1);
+            this.tableLayoutPanel1.Controls.Add(this.characterClassComboBox, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.classLabel, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.difficultyLabel, 1, 0);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(3, 14);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(0);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 2;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 14F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 22F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(331, 38);
+            this.tableLayoutPanel1.TabIndex = 8;
+            // 
+            // difficultyComboBox
+            // 
+            this.difficultyComboBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.difficultyComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.difficultyComboBox.FormattingEnabled = true;
+            this.difficultyComboBox.Location = new System.Drawing.Point(168, 17);
+            this.difficultyComboBox.Name = "difficultyComboBox";
+            this.difficultyComboBox.Size = new System.Drawing.Size(160, 21);
+            this.difficultyComboBox.TabIndex = 5;
+            this.difficultyComboBox.SelectedValueChanged += new System.EventHandler(this.DifficultyComboBoxOnSelectedValueChanged);
+            // 
+            // characterClassComboBox
+            // 
+            this.characterClassComboBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.characterClassComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.characterClassComboBox.FormattingEnabled = true;
+            this.characterClassComboBox.Location = new System.Drawing.Point(3, 17);
+            this.characterClassComboBox.Name = "characterClassComboBox";
+            this.characterClassComboBox.Size = new System.Drawing.Size(159, 21);
+            this.characterClassComboBox.TabIndex = 4;
+            this.characterClassComboBox.SelectedValueChanged += new System.EventHandler(this.CharacterClassComboBoxOnSelectedValueChanged);
+            // 
+            // classLabel
+            // 
+            this.classLabel.AutoSize = true;
+            this.classLabel.Location = new System.Drawing.Point(3, 0);
+            this.classLabel.Name = "classLabel";
+            this.classLabel.Size = new System.Drawing.Size(36, 13);
+            this.classLabel.TabIndex = 6;
+            this.classLabel.Text = "Class";
+            // 
+            // difficultyLabel
+            // 
+            this.difficultyLabel.AutoSize = true;
+            this.difficultyLabel.Location = new System.Drawing.Point(168, 0);
+            this.difficultyLabel.Name = "difficultyLabel";
+            this.difficultyLabel.Size = new System.Drawing.Size(51, 13);
+            this.difficultyLabel.TabIndex = 7;
+            this.difficultyLabel.Text = "Difficulty";
+            // 
+            // runeComboBox
+            // 
+            this.runeComboBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.runeComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.runeComboBox.FormattingEnabled = true;
+            this.runeComboBox.Location = new System.Drawing.Point(6, 57);
+            this.runeComboBox.Name = "runeComboBox";
+            this.runeComboBox.Size = new System.Drawing.Size(229, 21);
+            this.runeComboBox.TabIndex = 3;
+            this.runeComboBox.SelectedValueChanged += new System.EventHandler(this.RuneComboBoxOnSelectedValueChanged);
+            // 
+            // runeButton
+            // 
+            this.runeButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.runeButton.Enabled = false;
+            this.runeButton.Location = new System.Drawing.Point(241, 55);
+            this.runeButton.Name = "runeButton";
+            this.runeButton.Size = new System.Drawing.Size(90, 23);
+            this.runeButton.TabIndex = 0;
+            this.runeButton.Text = "Add";
+            this.runeButton.UseVisualStyleBackColor = true;
+            this.runeButton.Click += new System.EventHandler(this.RuneButtonOnClick);
+            // 
+            // RuneSettingsPage
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.splitContainer1);
+            this.Name = "RuneSettingsPage";
+            this.Size = new System.Drawing.Size(497, 440);
+            this.splitContainer1.Panel1.ResumeLayout(false);
+            this.splitContainer1.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
+            this.splitContainer1.ResumeLayout(false);
+            this.classSettingsGroupBox.ResumeLayout(false);
+            this.runesGroupBox.ResumeLayout(false);
+            this.runeListEditBox.ResumeLayout(false);
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.SplitContainer splitContainer1;
+        private System.Windows.Forms.GroupBox classSettingsGroupBox;
+        private System.Windows.Forms.ListBox characterListBox;
+        private System.Windows.Forms.FlowLayoutPanel runeFlowLayout;
+        private System.Windows.Forms.ComboBox runeComboBox;
+        private System.Windows.Forms.Button runeButton;
+        private System.Windows.Forms.Label difficultyLabel;
+        private System.Windows.Forms.Label classLabel;
+        private System.Windows.Forms.ComboBox difficultyComboBox;
+        private System.Windows.Forms.ComboBox characterClassComboBox;
+        private System.Windows.Forms.GroupBox runesGroupBox;
+        private System.Windows.Forms.GroupBox runeListEditBox;
+        private System.Windows.Forms.Button deleteSettingsButton;
+        private System.Windows.Forms.Button addSettingsButton;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+    }
+}

--- a/src/DiabloInterface/Gui/Controls/RuneSettingsPage.Designer.cs
+++ b/src/DiabloInterface/Gui/Controls/RuneSettingsPage.Designer.cs
@@ -43,6 +43,8 @@
             this.difficultyLabel = new System.Windows.Forms.Label();
             this.runeComboBox = new System.Windows.Forms.ComboBox();
             this.runeButton = new System.Windows.Forms.Button();
+            this.runewordComboBox = new System.Windows.Forms.ComboBox();
+            this.runewordButton = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
@@ -123,12 +125,13 @@
             // 
             // runesGroupBox
             // 
-            this.runesGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.runesGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.runesGroupBox.Controls.Add(this.runeFlowLayout);
             this.runesGroupBox.Location = new System.Drawing.Point(3, 3);
             this.runesGroupBox.Name = "runesGroupBox";
-            this.runesGroupBox.Size = new System.Drawing.Size(337, 344);
+            this.runesGroupBox.Size = new System.Drawing.Size(337, 313);
             this.runesGroupBox.TabIndex = 0;
             this.runesGroupBox.TabStop = false;
             this.runesGroupBox.Text = "Runes";
@@ -138,7 +141,7 @@
             this.runeFlowLayout.Dock = System.Windows.Forms.DockStyle.Fill;
             this.runeFlowLayout.Location = new System.Drawing.Point(3, 16);
             this.runeFlowLayout.Name = "runeFlowLayout";
-            this.runeFlowLayout.Size = new System.Drawing.Size(331, 325);
+            this.runeFlowLayout.Size = new System.Drawing.Size(331, 294);
             this.runeFlowLayout.TabIndex = 0;
             // 
             // runeListEditBox
@@ -148,16 +151,18 @@
             this.runeListEditBox.Controls.Add(this.tableLayoutPanel1);
             this.runeListEditBox.Controls.Add(this.runeComboBox);
             this.runeListEditBox.Controls.Add(this.runeButton);
-            this.runeListEditBox.Location = new System.Drawing.Point(3, 353);
+            this.runeListEditBox.Controls.Add(this.runewordComboBox);
+            this.runeListEditBox.Controls.Add(this.runewordButton);
+            this.runeListEditBox.Location = new System.Drawing.Point(3, 322);
             this.runeListEditBox.Name = "runeListEditBox";
-            this.runeListEditBox.Size = new System.Drawing.Size(337, 84);
+            this.runeListEditBox.Size = new System.Drawing.Size(337, 115);
             this.runeListEditBox.TabIndex = 0;
             this.runeListEditBox.TabStop = false;
             this.runeListEditBox.Text = "Edit";
             // 
             // tableLayoutPanel1
             // 
-            this.tableLayoutPanel1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            this.tableLayoutPanel1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel1.ColumnCount = 2;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
@@ -219,7 +224,7 @@
             // 
             // runeComboBox
             // 
-            this.runeComboBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            this.runeComboBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.runeComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.runeComboBox.FormattingEnabled = true;
@@ -227,12 +232,10 @@
             this.runeComboBox.Name = "runeComboBox";
             this.runeComboBox.Size = new System.Drawing.Size(229, 21);
             this.runeComboBox.TabIndex = 3;
-            this.runeComboBox.SelectedValueChanged += new System.EventHandler(this.RuneComboBoxOnSelectedValueChanged);
             // 
             // runeButton
             // 
-            this.runeButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.runeButton.Enabled = false;
+            this.runeButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.runeButton.Location = new System.Drawing.Point(241, 55);
             this.runeButton.Name = "runeButton";
             this.runeButton.Size = new System.Drawing.Size(90, 23);
@@ -240,6 +243,28 @@
             this.runeButton.Text = "Add";
             this.runeButton.UseVisualStyleBackColor = true;
             this.runeButton.Click += new System.EventHandler(this.RuneButtonOnClick);
+            // 
+            // runewordComboBox
+            // 
+            this.runewordComboBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.runewordComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.runewordComboBox.FormattingEnabled = true;
+            this.runewordComboBox.Location = new System.Drawing.Point(6, 86);
+            this.runewordComboBox.Name = "runewordComboBox";
+            this.runewordComboBox.Size = new System.Drawing.Size(229, 21);
+            this.runewordComboBox.TabIndex = 10;
+            // 
+            // runewordButton
+            // 
+            this.runewordButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.runewordButton.Location = new System.Drawing.Point(241, 84);
+            this.runewordButton.Name = "runewordButton";
+            this.runewordButton.Size = new System.Drawing.Size(90, 23);
+            this.runewordButton.TabIndex = 9;
+            this.runewordButton.Text = "Add";
+            this.runewordButton.UseVisualStyleBackColor = true;
+            this.runewordButton.Click += new System.EventHandler(this.RunewordButtonOnClick);
             // 
             // RuneSettingsPage
             // 
@@ -278,5 +303,7 @@
         private System.Windows.Forms.Button deleteSettingsButton;
         private System.Windows.Forms.Button addSettingsButton;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.ComboBox runewordComboBox;
+        private System.Windows.Forms.Button runewordButton;
     }
 }

--- a/src/DiabloInterface/Gui/Controls/RuneSettingsPage.cs
+++ b/src/DiabloInterface/Gui/Controls/RuneSettingsPage.cs
@@ -1,0 +1,333 @@
+﻿namespace Zutatensuppe.DiabloInterface.Gui.Controls
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Reflection;
+    using System.Windows.Forms;
+
+    using Newtonsoft.Json;
+
+    using Zutatensuppe.D2Reader.Models;
+    using Zutatensuppe.DiabloInterface.Business.Settings;
+    using Zutatensuppe.DiabloInterface.Core.Extensions;
+    using Zutatensuppe.DiabloInterface.Core.Logging;
+
+    public partial class RuneSettingsPage : UserControl
+    {
+        static readonly ILogger Logger = LogServiceLocator.Get(MethodBase.GetCurrentMethod().DeclaringType);
+
+        public RuneSettingsPage()
+        {
+            Logger.Info("Initializing rune settings page.");
+
+            InitializeComponent();
+            InitializeComboBoxes();
+        }
+
+        ClassRuneSettings currentSettings;
+        IReadOnlyList<ClassRuneSettings> settingsList;
+
+        public IReadOnlyList<ClassRuneSettings> SettingsList
+        {
+            get => settingsList;
+            set
+            {
+                settingsList = value;
+
+                var index = characterListBox.SelectedIndex;
+                characterListBox.Items.Clear();
+                IList<CharacterClassListItem> items =
+                    settingsList.Select(item => new CharacterClassListItem(item)).ToList();
+                characterListBox.Items.AddRange(items.OfType<object>().ToArray());
+                characterListBox.SelectedIndex = items.Any() ? (index < 0 ? 0 : index) : -1;
+
+                DisplayCharacterClassSettings();
+            }
+        }
+
+        ClassRuneSettings CurrentSettings
+        {
+            set
+            {
+                currentSettings = value;
+                if (currentSettings == null) return;
+
+                characterClassComboBox.SelectedIndex = currentSettings.Class.HasValue
+                    ? (int)currentSettings.Class.Value + 1 : 0;
+
+                difficultyComboBox.SelectedIndex = currentSettings.Difficulty.HasValue
+                    ? (int)currentSettings.Difficulty.Value + 1 : 0;
+
+                foreach (Control control in runeFlowLayout.Controls)
+                    control.Dispose();
+                runeFlowLayout.Controls.Clear();
+
+                currentSettings.Runes.ForEach(AddRune);
+            }
+        }
+
+        void InitializeComboBoxes()
+        {
+            InitializeCharacterClassComboBox();
+            InitializeDifficultyComboBox();
+            InitializeRuneComboBox();
+        }
+
+        void InitializeCharacterClassComboBox()
+        {
+            characterClassComboBox.Items.Clear();
+            characterClassComboBox.Items.Add("Default");
+            AddEnumValues(characterClassComboBox, typeof(CharacterClass));
+        }
+
+        void InitializeDifficultyComboBox()
+        {
+            difficultyComboBox.Items.Clear();
+            difficultyComboBox.Items.Add("Default");
+            AddEnumValues(difficultyComboBox, typeof(GameDifficulty));
+        }
+
+        void InitializeRuneComboBox()
+        {
+            runeComboBox.Items.Clear();
+
+            AddRunes(runeComboBox);
+            runeComboBox.Items.Add(new RuneListItem {Tag = "Separator"});
+            AddRunewords(runeComboBox);
+        }
+
+        void AddRunes(ComboBox comboBox)
+        {
+            IEnumerable<RuneListItem> runes =
+                from rune in Enum.GetValues(typeof(Rune)).OfType<Rune>()
+                select RuneListItem.CreateRune(rune);
+            comboBox.Items.AddRange(runes.OfType<object>().ToArray());
+        }
+
+        void AddRunewords(ComboBox comboBox)
+        {
+            IEnumerable<Runeword> runeWords = ReadRuneworsFile();
+            object[] items = (from runeWord in runeWords
+                    select RuneListItem.CreateRuneword(runeWord))
+                .OfType<object>().ToArray();
+            comboBox.Items.AddRange(items);
+        }
+
+        void AddEnumValues(ComboBox comboBox, Type enumType)
+        {
+            if (!enumType.IsEnum) throw new ArgumentException(@"Must be enum type.", nameof(enumType));
+            object[] enumValues = Enum.GetValues(enumType).OfType<object>().ToArray();
+            comboBox.Items.AddRange(enumValues);
+        }
+
+        IEnumerable<Runeword> ReadRuneworsFile()
+        {
+            using (var stream = new MemoryStream(Properties.Resources.runewords))
+            using (var streamReader = new StreamReader(stream))
+            using (var reader = new JsonTextReader(streamReader))
+            {
+                var serializer = new JsonSerializer();
+                return serializer.Deserialize<List<Runeword>>(reader);
+            }
+        }
+
+        void DisplayCharacterClassSettings()
+        {
+            if (characterListBox.SelectedIndex < 0)
+                return;
+
+            var item = characterListBox.SelectedItem as CharacterClassListItem;
+            if (item?.Settings == null) return;
+
+            CurrentSettings = item.Settings;
+        }
+
+        void RuneButtonOnClick(object sender, EventArgs e)
+        {
+            var item = runeComboBox.SelectedItem as RuneListItem;
+            if (item == null) return;
+
+            switch (item.Tag)
+            {
+                case "Rune":
+                    AddRune(item.Rune);
+                    break;
+                case "Runeword":
+                    item.Runeword.Runes.ForEach(AddRune);
+                    break;
+                default:
+                    return;
+            }
+        }
+
+        void AddRune(Rune rune)
+        {
+            var element = new RuneDisplayElement(rune);
+            element.RemoveButtonClicked += RuneElementOnRemoveButtonClicked;
+            runeFlowLayout.Controls.Add(element);
+
+            UpdateSettingsRuneList();
+        }
+
+        void RuneElementOnRemoveButtonClicked(object sender, EventArgs eventArgs)
+        {
+            var control = sender as RuneDisplayElement;
+            if (control == null) return;
+
+            runeFlowLayout.Controls.Remove(control);
+            control.Dispose();
+
+            UpdateSettingsRuneList();
+        }
+
+        void UpdateSettingsRuneList()
+        {
+            currentSettings.Runes =
+                (from RuneDisplayElement element in runeFlowLayout.Controls
+                 select element.Rune).ToList();
+        }
+
+        void RuneComboBoxOnSelectedValueChanged(object sender, EventArgs e)
+        {
+            var comboBox = sender as ComboBox;
+
+            var item = comboBox?.SelectedItem as RuneListItem;
+            if (item == null)
+            {
+                runeButton.Enabled = false;
+                return;
+            }
+
+            if (item.Tag == "Separator")
+                comboBox.SelectedIndex = -1;
+            else runeButton.Enabled = true;
+        }
+
+        void CharacterClassComboBoxOnSelectedValueChanged(object sender, EventArgs e)
+        {
+            var comboBox = sender as ComboBox;
+            if (comboBox == null) return;
+
+            if (comboBox.SelectedIndex == 0)
+                currentSettings.Class = null;
+            else currentSettings.Class = (CharacterClass)comboBox.SelectedItem;
+
+            RefreshSettingsItemText(currentSettings);
+        }
+
+        void DifficultyComboBoxOnSelectedValueChanged(object sender, EventArgs e)
+        {
+            var comboBox = sender as ComboBox;
+            if (comboBox == null) return;
+
+            if (comboBox.SelectedIndex == 0)
+                currentSettings.Difficulty = null;
+            else currentSettings.Difficulty = (GameDifficulty)comboBox.SelectedItem;
+
+            RefreshSettingsItemText(currentSettings);
+        }
+
+        void RefreshSettingsItemText(ClassRuneSettings settings)
+        {
+            var items = characterListBox.Items;
+            for (var i = 0; i < items.Count; ++i)
+            {
+                var item = (CharacterClassListItem)items[i];
+                if (item.Settings != settings) continue;
+
+                // Modifying the item collection forces the text to update.
+                items[i] = item;
+                break;
+            }
+        }
+
+        void AddSettingsButtonOnClick(object sender, EventArgs e)
+        {
+            List<ClassRuneSettings> settings = settingsList.ToList();
+            settings.Add(new ClassRuneSettings());
+            SettingsList = settings;
+
+            characterListBox.SelectedIndex = characterListBox.Items.Count - 1;
+            CurrentSettings = settings.Last();
+        }
+
+        void DeleteSettingsButtonOnClick(object sender, EventArgs e)
+        {
+            if (characterListBox.SelectedIndex < 0) return;
+
+            var selected = characterListBox.SelectedItem as CharacterClassListItem;
+            var settings = selected?.Settings;
+
+            if (settings == null) return;
+
+            SettingsList = settingsList.Where(s => s != settings).ToList();
+        }
+
+        void CharacterListBoxOnMouseDoubleClick(object sender, MouseEventArgs e)
+        {
+            var listBox = (ListBox)sender;
+            var index = listBox.IndexFromPoint(e.Location);
+            if (index == ListBox.NoMatches) return;
+
+            var item = listBox.Items[index] as CharacterClassListItem;
+            if (item == null) return;
+
+            CurrentSettings = item.Settings;
+        }
+
+        class CharacterClassListItem
+        {
+            public CharacterClassListItem(ClassRuneSettings settings)
+            {
+                Settings = settings ?? throw new ArgumentNullException(nameof(settings));
+            }
+
+            public ClassRuneSettings Settings { get; }
+
+            public override string ToString()
+            {
+                if (!Settings.Difficulty.HasValue)
+                    return Settings.Class.HasValue ? $"{Settings.Class}" : "Default";
+
+                return Settings.Class.HasValue
+                    ? $"{Settings.Class} {Settings.Difficulty}"
+                    : $"Default {Settings.Difficulty}";
+            }
+        }
+
+        class RuneListItem
+        {
+            public string Tag { get; set; }
+            public Runeword Runeword { get; private set; }
+            public Rune Rune { get; private set; }
+
+            public static RuneListItem CreateRuneword(Runeword runeword)
+            {
+                return new RuneListItem()
+                {
+                    Tag = "Runeword",
+                    Runeword = runeword
+                };
+            }
+
+            public static RuneListItem CreateRune(Rune rune)
+            {
+                return new RuneListItem()
+                {
+                    Tag = "Rune",
+                    Rune = rune
+                };
+            }
+
+            public override string ToString()
+            {
+                if (Tag == "Runeword") return Runeword?.Name ?? "Unknown Runeword";
+                if (Tag == "Rune") return Rune.ToString();
+
+                return new string('-', 20);
+            }
+        }
+    }
+}

--- a/src/DiabloInterface/Gui/Controls/RuneSettingsPage.cs
+++ b/src/DiabloInterface/Gui/Controls/RuneSettingsPage.cs
@@ -41,6 +41,11 @@
                 IList<CharacterClassListItem> items =
                     settingsList.Select(item => new CharacterClassListItem(item)).ToList();
                 characterListBox.Items.AddRange(items.OfType<object>().ToArray());
+                if (index >= characterListBox.Items.Count)
+                {
+                    index = characterListBox.Items.Count - 1;
+                }
+                
                 characterListBox.SelectedIndex = items.Any() ? (index < 0 ? 0 : index) : -1;
 
                 DisplayCharacterClassSettings();

--- a/src/DiabloInterface/Gui/Controls/RuneSettingsPage.cs
+++ b/src/DiabloInterface/Gui/Controls/RuneSettingsPage.cs
@@ -57,18 +57,29 @@
             set
             {
                 currentSettings = value;
-                if (currentSettings == null) return;
+                if (currentSettings == null)
+                {
+                    runeComboBox.Enabled = false;
+                    characterClassComboBox.Enabled = false;
+                    characterClassComboBox.SelectedIndex = -1;
+                    difficultyComboBox.Enabled = false;
+                    difficultyComboBox.SelectedIndex = -1;
+                    runeFlowLayout.Controls.ClearAndDispose();
 
+                    return;
+                }
+
+                runeComboBox.Enabled = true;
+
+                characterClassComboBox.Enabled = true;
                 characterClassComboBox.SelectedIndex = currentSettings.Class.HasValue
                     ? (int)currentSettings.Class.Value + 1 : 0;
 
+                difficultyComboBox.Enabled = true;
                 difficultyComboBox.SelectedIndex = currentSettings.Difficulty.HasValue
                     ? (int)currentSettings.Difficulty.Value + 1 : 0;
 
-                foreach (Control control in runeFlowLayout.Controls)
-                    control.Dispose();
-                runeFlowLayout.Controls.Clear();
-
+                runeFlowLayout.Controls.ClearAndDispose();
                 currentSettings.Runes.ForEach(AddRune);
             }
         }
@@ -141,7 +152,12 @@
         void DisplayCharacterClassSettings()
         {
             if (characterListBox.SelectedIndex < 0)
+            {
+                if (characterListBox.Items.Count <= 0)
+                    CurrentSettings = null;
+
                 return;
+            }
 
             var item = characterListBox.SelectedItem as CharacterClassListItem;
             if (item?.Settings == null) return;
@@ -212,6 +228,7 @@
 
         void CharacterClassComboBoxOnSelectedValueChanged(object sender, EventArgs e)
         {
+            if (currentSettings == null) return;
             var comboBox = sender as ComboBox;
             if (comboBox == null) return;
 
@@ -224,6 +241,7 @@
 
         void DifficultyComboBoxOnSelectedValueChanged(object sender, EventArgs e)
         {
+            if (currentSettings == null) return;
             var comboBox = sender as ComboBox;
             if (comboBox == null) return;
 

--- a/src/DiabloInterface/Gui/Controls/RuneSettingsPage.cs
+++ b/src/DiabloInterface/Gui/Controls/RuneSettingsPage.cs
@@ -167,7 +167,7 @@
 
         void RuneButtonOnClick(object sender, EventArgs e)
         {
-            if (runeComboBox.SelectedIndex <= 0) return;
+            if (runeComboBox.SelectedIndex < 0) return;
             AddRune((Rune)runeComboBox.SelectedItem);
         }
 

--- a/src/DiabloInterface/Gui/Controls/RuneSettingsPage.resx
+++ b/src/DiabloInterface/Gui/Controls/RuneSettingsPage.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/DiabloInterface/Gui/Controls/VerticalLayout.cs
+++ b/src/DiabloInterface/Gui/Controls/VerticalLayout.cs
@@ -9,6 +9,7 @@
     using Zutatensuppe.D2Reader.Models;
     using Zutatensuppe.DiabloInterface.Business.Services;
     using Zutatensuppe.DiabloInterface.Business.Settings;
+    using Zutatensuppe.DiabloInterface.Core.Extensions;
     using Zutatensuppe.DiabloInterface.Core.Logging;
 
     public partial class VerticalLayout : AbstractLayout
@@ -102,6 +103,14 @@
             UpdateLabelWidthAlignment(normLabelVal, nmLabelVal, hellLabelVal);
         }
 
+        protected override void UpdateRuneList(ApplicationSettings settings, IReadOnlyList<Rune> runes)
+        {
+            panelRuneDisplay2.Visible = runes.Count > 0;
+            panelRuneDisplay2.Controls.Clear();
+            runes.ForEach(rune => panelRuneDisplay2.Controls.Add(
+                new RuneDisplayElement(rune, settings.DisplayRunesHighContrast, false, false)));
+        }
+
         void UpdateLayout(ApplicationSettings settings)
         {
             bool first = true;
@@ -165,22 +174,12 @@
                 panelDiffPercentages.Margin = new Padding(panelDiffPercentages.Margin.Left, first ? 0 : settings.VerticalLayoutPadding, panelDiffPercentages.Margin.Right, panelDiffPercentages.Margin.Bottom);
                 first = false;
             }
-
         }
 
         void ApplyRuneSettings(ApplicationSettings settings)
         {
-            if (settings.DisplayRunes && settings.Runes.Count > 0)
-            {
-                panelRuneDisplay2.Controls.Clear();
-                settings.Runes.ForEach(r => { panelRuneDisplay2.Controls.Add(new RuneDisplayElement((Rune)r, settings.DisplayRunesHighContrast, false, false)); });
-
-                panelRuneDisplay2.Show();
-            }
-            else
-            {
+            if (!settings.DisplayRunes)
                 panelRuneDisplay2.Hide();
-            }
         }
 
         void ApplyLabelSettings(ApplicationSettings settings)

--- a/src/DiabloInterface/Gui/Controls/VerticalLayout.cs
+++ b/src/DiabloInterface/Gui/Controls/VerticalLayout.cs
@@ -9,7 +9,6 @@
     using Zutatensuppe.D2Reader.Models;
     using Zutatensuppe.DiabloInterface.Business.Services;
     using Zutatensuppe.DiabloInterface.Business.Settings;
-    using Zutatensuppe.DiabloInterface.Core.Extensions;
     using Zutatensuppe.DiabloInterface.Core.Logging;
 
     public partial class VerticalLayout : AbstractLayout
@@ -26,6 +25,8 @@
             InitializeComponent();
             InitializeElements();
         }
+
+        protected override Panel RuneLayoutPanel => panelRuneDisplay2;
 
         void InitializeElements()
         {
@@ -65,8 +66,6 @@
 
         protected override void UpdateSettings(ApplicationSettings settings)
         {
-            base.UpdateSettings(settings);
-
             ApplyLabelSettings(settings);
             ApplyRuneSettings(settings);
             UpdateLayout(settings);
@@ -101,14 +100,6 @@
             nmLabelVal.Text = $@"{quests[1].CompletionProgress:0%}";
             hellLabelVal.Text = $@"{quests[2].CompletionProgress:0%}";
             UpdateLabelWidthAlignment(normLabelVal, nmLabelVal, hellLabelVal);
-        }
-
-        protected override void UpdateRuneList(ApplicationSettings settings, IReadOnlyList<Rune> runes)
-        {
-            panelRuneDisplay2.Visible = runes.Count > 0;
-            panelRuneDisplay2.Controls.Clear();
-            runes.ForEach(rune => panelRuneDisplay2.Controls.Add(
-                new RuneDisplayElement(rune, settings.DisplayRunesHighContrast, false, false)));
         }
 
         void UpdateLayout(ApplicationSettings settings)

--- a/src/DiabloInterface/Gui/MainWindow.Designer.cs
+++ b/src/DiabloInterface/Gui/MainWindow.Designer.cs
@@ -36,33 +36,38 @@
             this.resetToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.debugMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.difficultyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.normalToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.nightmareToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.hellToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.contextMenu.SuspendLayout();
             this.SuspendLayout();
             // 
             // contextMenu
             // 
             this.contextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.difficultyToolStripMenuItem,
             this.settingsToolStripMenuItem,
             this.loadConfigMenuItem,
             this.resetToolStripMenuItem,
             this.debugMenuItem,
             this.exitToolStripMenuItem});
             this.contextMenu.Name = "contextMenu";
-            this.contextMenu.Size = new System.Drawing.Size(161, 114);
+            this.contextMenu.Size = new System.Drawing.Size(172, 158);
             // 
             // settingsToolStripMenuItem
             // 
             this.settingsToolStripMenuItem.Image = global::Zutatensuppe.DiabloInterface.Properties.Resources.wrench_orange;
             this.settingsToolStripMenuItem.Name = "settingsToolStripMenuItem";
             this.settingsToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.U)));
-            this.settingsToolStripMenuItem.Size = new System.Drawing.Size(160, 22);
+            this.settingsToolStripMenuItem.Size = new System.Drawing.Size(171, 22);
             this.settingsToolStripMenuItem.Text = "Settings";
             this.settingsToolStripMenuItem.Click += new System.EventHandler(this.SettingsMenuItemOnClick);
             // 
             // loadConfigMenuItem
             // 
             this.loadConfigMenuItem.Name = "loadConfigMenuItem";
-            this.loadConfigMenuItem.Size = new System.Drawing.Size(160, 22);
+            this.loadConfigMenuItem.Size = new System.Drawing.Size(171, 22);
             this.loadConfigMenuItem.Text = "Load Config";
             // 
             // resetToolStripMenuItem
@@ -70,7 +75,7 @@
             this.resetToolStripMenuItem.Image = global::Zutatensuppe.DiabloInterface.Properties.Resources.arrow_refresh;
             this.resetToolStripMenuItem.Name = "resetToolStripMenuItem";
             this.resetToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.R)));
-            this.resetToolStripMenuItem.Size = new System.Drawing.Size(160, 22);
+            this.resetToolStripMenuItem.Size = new System.Drawing.Size(171, 22);
             this.resetToolStripMenuItem.Text = "Reset";
             this.resetToolStripMenuItem.Click += new System.EventHandler(this.ResetMenuItemOnClick);
             // 
@@ -78,7 +83,7 @@
             // 
             this.debugMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("debugMenuItem.Image")));
             this.debugMenuItem.Name = "debugMenuItem";
-            this.debugMenuItem.Size = new System.Drawing.Size(160, 22);
+            this.debugMenuItem.Size = new System.Drawing.Size(171, 22);
             this.debugMenuItem.Text = "Debug";
             this.debugMenuItem.Click += new System.EventHandler(this.DebugMenuItemOnClick);
             // 
@@ -86,9 +91,42 @@
             // 
             this.exitToolStripMenuItem.Image = global::Zutatensuppe.DiabloInterface.Properties.Resources.cross;
             this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-            this.exitToolStripMenuItem.Size = new System.Drawing.Size(160, 22);
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(171, 22);
             this.exitToolStripMenuItem.Text = "Exit";
             this.exitToolStripMenuItem.Click += new System.EventHandler(this.ExitMenuItemOnClick);
+            // 
+            // difficultyToolStripMenuItem
+            // 
+            this.difficultyToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.normalToolStripMenuItem,
+            this.nightmareToolStripMenuItem,
+            this.hellToolStripMenuItem});
+            this.difficultyToolStripMenuItem.Name = "difficultyToolStripMenuItem";
+            this.difficultyToolStripMenuItem.Size = new System.Drawing.Size(171, 22);
+            this.difficultyToolStripMenuItem.Text = "Difficulty";
+            // 
+            // normalToolStripMenuItem
+            // 
+            this.normalToolStripMenuItem.Checked = true;
+            this.normalToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.normalToolStripMenuItem.Name = "normalToolStripMenuItem";
+            this.normalToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.normalToolStripMenuItem.Text = "Normal";
+            this.normalToolStripMenuItem.Click += new System.EventHandler(this.DifficultyNormalToolStripMenuItemOnClick);
+            // 
+            // nightmareToolStripMenuItem
+            // 
+            this.nightmareToolStripMenuItem.Name = "nightmareToolStripMenuItem";
+            this.nightmareToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.nightmareToolStripMenuItem.Text = "Nightmare";
+            this.nightmareToolStripMenuItem.Click += new System.EventHandler(this.NightmareToolStripMenuItemOnClick);
+            // 
+            // hellToolStripMenuItem
+            // 
+            this.hellToolStripMenuItem.Name = "hellToolStripMenuItem";
+            this.hellToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.hellToolStripMenuItem.Text = "Hell";
+            this.hellToolStripMenuItem.Click += new System.EventHandler(this.HellToolStripMenuItemOnClick);
             // 
             // MainWindow
             // 
@@ -118,6 +156,10 @@
         private System.Windows.Forms.ToolStripMenuItem exitToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem debugMenuItem;
         private System.Windows.Forms.ToolStripMenuItem loadConfigMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem difficultyToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem normalToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem nightmareToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem hellToolStripMenuItem;
     }
 }
 

--- a/src/DiabloInterface/Gui/MainWindow.cs
+++ b/src/DiabloInterface/Gui/MainWindow.cs
@@ -195,6 +195,8 @@
 
         void GameDifficultyClick(object sender, GameDifficulty difficulty)
         {
+            Logger.Info($"Setting target difficulty to {difficulty}.");
+
             UncheckDifficultyMenuItems();
             gameService.TargetDifficulty = difficulty;
             ((ToolStripMenuItem)sender).Checked = true;

--- a/src/DiabloInterface/Gui/MainWindow.cs
+++ b/src/DiabloInterface/Gui/MainWindow.cs
@@ -7,6 +7,7 @@
     using System.Reflection;
     using System.Windows.Forms;
 
+    using Zutatensuppe.D2Reader.Models;
     using Zutatensuppe.DiabloInterface.Business.Services;
     using Zutatensuppe.DiabloInterface.Business.Settings;
     using Zutatensuppe.DiabloInterface.Core.Logging;
@@ -175,6 +176,35 @@
             }
 
             debugWindow.Show();
+        }
+
+        void DifficultyNormalToolStripMenuItemOnClick(object sender, EventArgs e)
+        {
+            UnheckDifficultyMenuItems();
+            gameService.TargetDifficulty = GameDifficulty.Normal;
+            normalToolStripMenuItem.Checked = true;
+        }
+
+        void NightmareToolStripMenuItemOnClick(object sender, EventArgs e)
+        {
+            UnheckDifficultyMenuItems();
+            gameService.TargetDifficulty = GameDifficulty.Nightmare;
+            nightmareToolStripMenuItem.Checked = true;
+        }
+
+        void HellToolStripMenuItemOnClick(object sender, EventArgs e)
+        {
+            UnheckDifficultyMenuItems();
+            gameService.TargetDifficulty = GameDifficulty.Hell;
+            hellToolStripMenuItem.Checked = true;
+        }
+
+        void UnheckDifficultyMenuItems()
+        {
+            foreach (ToolStripMenuItem item in difficultyToolStripMenuItem.DropDownItems)
+            {
+                item.Checked = false;
+            }
         }
 
         protected override void OnFormClosing(FormClosingEventArgs e)

--- a/src/DiabloInterface/Gui/MainWindow.cs
+++ b/src/DiabloInterface/Gui/MainWindow.cs
@@ -180,26 +180,27 @@
 
         void DifficultyNormalToolStripMenuItemOnClick(object sender, EventArgs e)
         {
-            UnheckDifficultyMenuItems();
-            gameService.TargetDifficulty = GameDifficulty.Normal;
-            normalToolStripMenuItem.Checked = true;
+            GameDifficultyClick(sender, GameDifficulty.Normal);
         }
 
         void NightmareToolStripMenuItemOnClick(object sender, EventArgs e)
         {
-            UnheckDifficultyMenuItems();
-            gameService.TargetDifficulty = GameDifficulty.Nightmare;
-            nightmareToolStripMenuItem.Checked = true;
+            GameDifficultyClick(sender, GameDifficulty.Nightmare);
         }
 
         void HellToolStripMenuItemOnClick(object sender, EventArgs e)
         {
-            UnheckDifficultyMenuItems();
-            gameService.TargetDifficulty = GameDifficulty.Hell;
-            hellToolStripMenuItem.Checked = true;
+            GameDifficultyClick(sender, GameDifficulty.Hell);
         }
 
-        void UnheckDifficultyMenuItems()
+        void GameDifficultyClick(object sender, GameDifficulty difficulty)
+        {
+            UncheckDifficultyMenuItems();
+            gameService.TargetDifficulty = difficulty;
+            ((ToolStripMenuItem)sender).Checked = true;
+        }
+
+        void UncheckDifficultyMenuItems()
         {
             foreach (ToolStripMenuItem item in difficultyToolStripMenuItem.DropDownItems)
             {

--- a/src/DiabloInterface/Gui/SettingsWindow.Designer.cs
+++ b/src/DiabloInterface/Gui/SettingsWindow.Designer.cs
@@ -44,10 +44,6 @@
             this.AutoSplitTestHotkeyButton = new System.Windows.Forms.Button();
             this.EnableAutosplitCheckBox = new System.Windows.Forms.CheckBox();
             this.AddAutoSplitButton = new System.Windows.Forms.Button();
-            this.btnAddRuneWord = new System.Windows.Forms.Button();
-            this.cbRuneWord = new System.Windows.Forms.ComboBox();
-            this.AddRuneButton = new System.Windows.Forms.Button();
-            this.RuneComboBox = new System.Windows.Forms.ComboBox();
             this.VerticalSplitContainer = new System.Windows.Forms.TableLayoutPanel();
             this.grpConfigFiles = new System.Windows.Forms.GroupBox();
             this.lstConfigFiles = new System.Windows.Forms.ListBox();
@@ -93,9 +89,7 @@
             this.chkDisplayDeathCounter = new System.Windows.Forms.CheckBox();
             this.chkDisplayName = new System.Windows.Forms.CheckBox();
             this.tabPageSettingsRunes = new System.Windows.Forms.TabPage();
-            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.panel2 = new System.Windows.Forms.Panel();
-            this.RuneDisplayPanel = new System.Windows.Forms.FlowLayoutPanel();
+            this.runeSettingsPage = new Zutatensuppe.DiabloInterface.Gui.Controls.RuneSettingsPage();
             this.tabPageSettingsAutosplit = new System.Windows.Forms.TabPage();
             this.tabPageSettingsMisc = new System.Windows.Forms.TabPage();
             this.DataGroup = new System.Windows.Forms.GroupBox();
@@ -123,8 +117,6 @@
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownPaddingInVerticalLayout)).BeginInit();
             this.groupBox1.SuspendLayout();
             this.tabPageSettingsRunes.SuspendLayout();
-            this.tableLayoutPanel1.SuspendLayout();
-            this.panel2.SuspendLayout();
             this.tabPageSettingsAutosplit.SuspendLayout();
             this.tabPageSettingsMisc.SuspendLayout();
             this.DataGroup.SuspendLayout();
@@ -138,7 +130,7 @@
             this.FontLabel.AutoSize = true;
             this.FontLabel.Location = new System.Drawing.Point(6, 24);
             this.FontLabel.Name = "FontLabel";
-            this.FontLabel.Size = new System.Drawing.Size(31, 13);
+            this.FontLabel.Size = new System.Drawing.Size(32, 13);
             this.FontLabel.TabIndex = 2;
             this.FontLabel.Text = "Font:";
             // 
@@ -209,7 +201,7 @@
             this.FontSizeLabel.AutoSize = true;
             this.FontSizeLabel.Location = new System.Drawing.Point(6, 51);
             this.FontSizeLabel.Name = "FontSizeLabel";
-            this.FontSizeLabel.Size = new System.Drawing.Size(52, 13);
+            this.FontSizeLabel.Size = new System.Drawing.Size(56, 13);
             this.FontSizeLabel.TabIndex = 7;
             this.FontSizeLabel.Text = "Font size:";
             // 
@@ -218,7 +210,7 @@
             this.TitleFontSizeLabel.AutoSize = true;
             this.TitleFontSizeLabel.Location = new System.Drawing.Point(6, 77);
             this.TitleFontSizeLabel.Name = "TitleFontSizeLabel";
-            this.TitleFontSizeLabel.Size = new System.Drawing.Size(80, 13);
+            this.TitleFontSizeLabel.Size = new System.Drawing.Size(84, 13);
             this.TitleFontSizeLabel.TabIndex = 6;
             this.TitleFontSizeLabel.Text = "Name font size:";
             // 
@@ -234,7 +226,7 @@
             this.AutoSplitLayout.RowCount = 2;
             this.AutoSplitLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.AutoSplitLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.AutoSplitLayout.Size = new System.Drawing.Size(497, 439);
+            this.AutoSplitLayout.Size = new System.Drawing.Size(497, 440);
             this.AutoSplitLayout.TabIndex = 21;
             // 
             // AutoSplitToolbar
@@ -246,7 +238,7 @@
             this.AutoSplitToolbar.Controls.Add(this.EnableAutosplitCheckBox);
             this.AutoSplitToolbar.Controls.Add(this.AddAutoSplitButton);
             this.AutoSplitToolbar.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.AutoSplitToolbar.Location = new System.Drawing.Point(0, 408);
+            this.AutoSplitToolbar.Location = new System.Drawing.Point(0, 409);
             this.AutoSplitToolbar.Margin = new System.Windows.Forms.Padding(0);
             this.AutoSplitToolbar.Name = "AutoSplitToolbar";
             this.AutoSplitToolbar.Size = new System.Drawing.Size(497, 31);
@@ -268,7 +260,7 @@
             this.AutoSplitHotkeyLabel.AutoSize = true;
             this.AutoSplitHotkeyLabel.Location = new System.Drawing.Point(3, 10);
             this.AutoSplitHotkeyLabel.Name = "AutoSplitHotkeyLabel";
-            this.AutoSplitHotkeyLabel.Size = new System.Drawing.Size(67, 13);
+            this.AutoSplitHotkeyLabel.Size = new System.Drawing.Size(71, 13);
             this.AutoSplitHotkeyLabel.TabIndex = 13;
             this.AutoSplitHotkeyLabel.Text = "Split-Hotkey:";
             // 
@@ -286,9 +278,9 @@
             // 
             this.EnableAutosplitCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.EnableAutosplitCheckBox.AutoSize = true;
-            this.EnableAutosplitCheckBox.Location = new System.Drawing.Point(350, 9);
+            this.EnableAutosplitCheckBox.Location = new System.Drawing.Point(349, 9);
             this.EnableAutosplitCheckBox.Name = "EnableAutosplitCheckBox";
-            this.EnableAutosplitCheckBox.Size = new System.Drawing.Size(59, 17);
+            this.EnableAutosplitCheckBox.Size = new System.Drawing.Size(60, 17);
             this.EnableAutosplitCheckBox.TabIndex = 1;
             this.EnableAutosplitCheckBox.Text = "Enable";
             this.EnableAutosplitCheckBox.UseVisualStyleBackColor = true;
@@ -304,48 +296,6 @@
             this.AddAutoSplitButton.UseVisualStyleBackColor = true;
             this.AddAutoSplitButton.Click += new System.EventHandler(this.AddAutoSplitButton_Clicked);
             // 
-            // btnAddRuneWord
-            // 
-            this.btnAddRuneWord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnAddRuneWord.Location = new System.Drawing.Point(398, 5);
-            this.btnAddRuneWord.Name = "btnAddRuneWord";
-            this.btnAddRuneWord.Size = new System.Drawing.Size(96, 23);
-            this.btnAddRuneWord.TabIndex = 4;
-            this.btnAddRuneWord.Text = "Add Runeword";
-            this.btnAddRuneWord.UseVisualStyleBackColor = true;
-            this.btnAddRuneWord.Click += new System.EventHandler(this.btnAddRuneWord_Click);
-            // 
-            // cbRuneWord
-            // 
-            this.cbRuneWord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.cbRuneWord.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cbRuneWord.FormattingEnabled = true;
-            this.cbRuneWord.Location = new System.Drawing.Point(292, 6);
-            this.cbRuneWord.Name = "cbRuneWord";
-            this.cbRuneWord.Size = new System.Drawing.Size(100, 21);
-            this.cbRuneWord.TabIndex = 3;
-            // 
-            // AddRuneButton
-            // 
-            this.AddRuneButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.AddRuneButton.Location = new System.Drawing.Point(195, 5);
-            this.AddRuneButton.Name = "AddRuneButton";
-            this.AddRuneButton.Size = new System.Drawing.Size(93, 23);
-            this.AddRuneButton.TabIndex = 1;
-            this.AddRuneButton.Text = "Add Rune";
-            this.AddRuneButton.UseVisualStyleBackColor = true;
-            this.AddRuneButton.Click += new System.EventHandler(this.AddRuneButton_Click);
-            // 
-            // RuneComboBox
-            // 
-            this.RuneComboBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.RuneComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.RuneComboBox.FormattingEnabled = true;
-            this.RuneComboBox.Location = new System.Drawing.Point(130, 6);
-            this.RuneComboBox.Name = "RuneComboBox";
-            this.RuneComboBox.Size = new System.Drawing.Size(59, 21);
-            this.RuneComboBox.TabIndex = 0;
-            // 
             // VerticalSplitContainer
             // 
             this.VerticalSplitContainer.ColumnCount = 2;
@@ -359,7 +309,7 @@
             this.VerticalSplitContainer.Name = "VerticalSplitContainer";
             this.VerticalSplitContainer.RowCount = 1;
             this.VerticalSplitContainer.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.VerticalSplitContainer.Size = new System.Drawing.Size(686, 471);
+            this.VerticalSplitContainer.Size = new System.Drawing.Size(686, 472);
             this.VerticalSplitContainer.TabIndex = 20;
             // 
             // grpConfigFiles
@@ -368,7 +318,7 @@
             this.grpConfigFiles.Dock = System.Windows.Forms.DockStyle.Fill;
             this.grpConfigFiles.Location = new System.Drawing.Point(3, 3);
             this.grpConfigFiles.Name = "grpConfigFiles";
-            this.grpConfigFiles.Size = new System.Drawing.Size(169, 465);
+            this.grpConfigFiles.Size = new System.Drawing.Size(169, 466);
             this.grpConfigFiles.TabIndex = 3;
             this.grpConfigFiles.TabStop = false;
             this.grpConfigFiles.Text = "Config Files";
@@ -380,7 +330,7 @@
             this.lstConfigFiles.FormattingEnabled = true;
             this.lstConfigFiles.Location = new System.Drawing.Point(3, 16);
             this.lstConfigFiles.Name = "lstConfigFiles";
-            this.lstConfigFiles.Size = new System.Drawing.Size(163, 446);
+            this.lstConfigFiles.Size = new System.Drawing.Size(163, 447);
             this.lstConfigFiles.TabIndex = 2;
             this.lstConfigFiles.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.lstConfigFiles_MouseDoubleClick);
             this.lstConfigFiles.MouseUp += new System.Windows.Forms.MouseEventHandler(this.lstConfigFiles_MouseUp);
@@ -394,40 +344,40 @@
             this.menuClone,
             this.menuDelete});
             this.ctxConfigFileList.Name = "ctxConfigFileList";
-            this.ctxConfigFileList.Size = new System.Drawing.Size(118, 114);
+            this.ctxConfigFileList.Size = new System.Drawing.Size(124, 114);
             // 
             // menuNew
             // 
             this.menuNew.Name = "menuNew";
-            this.menuNew.Size = new System.Drawing.Size(117, 22);
+            this.menuNew.Size = new System.Drawing.Size(123, 22);
             this.menuNew.Text = "New";
             this.menuNew.Click += new System.EventHandler(this.menuNew_Click);
             // 
             // menuLoad
             // 
             this.menuLoad.Name = "menuLoad";
-            this.menuLoad.Size = new System.Drawing.Size(117, 22);
+            this.menuLoad.Size = new System.Drawing.Size(123, 22);
             this.menuLoad.Text = "Load";
             this.menuLoad.Click += new System.EventHandler(this.menuLoad_Click);
             // 
             // renameToolStripMenuItem
             // 
             this.renameToolStripMenuItem.Name = "renameToolStripMenuItem";
-            this.renameToolStripMenuItem.Size = new System.Drawing.Size(117, 22);
+            this.renameToolStripMenuItem.Size = new System.Drawing.Size(123, 22);
             this.renameToolStripMenuItem.Text = "Rename";
             this.renameToolStripMenuItem.Click += new System.EventHandler(this.renameToolStripMenuItem_Click);
             // 
             // menuClone
             // 
             this.menuClone.Name = "menuClone";
-            this.menuClone.Size = new System.Drawing.Size(117, 22);
+            this.menuClone.Size = new System.Drawing.Size(123, 22);
             this.menuClone.Text = "Clone";
             this.menuClone.Click += new System.EventHandler(this.menuClone_Click);
             // 
             // menuDelete
             // 
             this.menuDelete.Name = "menuDelete";
-            this.menuDelete.Size = new System.Drawing.Size(117, 22);
+            this.menuDelete.Size = new System.Drawing.Size(123, 22);
             this.menuDelete.Text = "Delete";
             this.menuDelete.Click += new System.EventHandler(this.menuDelete_Click);
             // 
@@ -444,7 +394,7 @@
             this.HorizontalSplitContainer.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.HorizontalSplitContainer.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.HorizontalSplitContainer.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.HorizontalSplitContainer.Size = new System.Drawing.Size(511, 471);
+            this.HorizontalSplitContainer.Size = new System.Drawing.Size(511, 472);
             this.HorizontalSplitContainer.TabIndex = 0;
             // 
             // tabControl1
@@ -457,7 +407,7 @@
             this.tabControl1.Location = new System.Drawing.Point(3, 3);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(505, 465);
+            this.tabControl1.Size = new System.Drawing.Size(505, 466);
             this.tabControl1.TabIndex = 13;
             // 
             // tabPageSettingsLayout
@@ -468,7 +418,7 @@
             this.tabPageSettingsLayout.Location = new System.Drawing.Point(4, 22);
             this.tabPageSettingsLayout.Name = "tabPageSettingsLayout";
             this.tabPageSettingsLayout.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPageSettingsLayout.Size = new System.Drawing.Size(497, 439);
+            this.tabPageSettingsLayout.Size = new System.Drawing.Size(497, 440);
             this.tabPageSettingsLayout.TabIndex = 1;
             this.tabPageSettingsLayout.Text = "Layout";
             this.tabPageSettingsLayout.UseVisualStyleBackColor = true;
@@ -500,7 +450,7 @@
             this.label3.AutoSize = true;
             this.label3.Location = new System.Drawing.Point(6, 51);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(93, 13);
+            this.label3.Size = new System.Drawing.Size(97, 13);
             this.label3.TabIndex = 21;
             this.label3.Text = "Runes orientation:";
             // 
@@ -521,7 +471,7 @@
             this.label2.AutoSize = true;
             this.label2.Location = new System.Drawing.Point(6, 24);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(61, 13);
+            this.label2.Size = new System.Drawing.Size(65, 13);
             this.label2.TabIndex = 21;
             this.label2.Text = "Orientation:";
             // 
@@ -530,7 +480,7 @@
             this.label1.AutoSize = true;
             this.label1.Location = new System.Drawing.Point(6, 77);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(128, 13);
+            this.label1.Size = new System.Drawing.Size(135, 13);
             this.label1.TabIndex = 19;
             this.label1.Text = "Padding in vertical layout:";
             // 
@@ -586,7 +536,7 @@
             this.chkShowRealValues.AutoSize = true;
             this.chkShowRealValues.Location = new System.Drawing.Point(207, 120);
             this.chkShowRealValues.Name = "chkShowRealValues";
-            this.chkShowRealValues.Size = new System.Drawing.Size(170, 17);
+            this.chkShowRealValues.Size = new System.Drawing.Size(174, 17);
             this.chkShowRealValues.TabIndex = 27;
             this.chkShowRealValues.Text = "show real values for FRW/IAS";
             this.chkShowRealValues.UseVisualStyleBackColor = true;
@@ -596,7 +546,7 @@
             this.chkHighContrastRunes.AutoSize = true;
             this.chkHighContrastRunes.Location = new System.Drawing.Point(127, 303);
             this.chkHighContrastRunes.Name = "chkHighContrastRunes";
-            this.chkHighContrastRunes.Size = new System.Drawing.Size(89, 17);
+            this.chkHighContrastRunes.Size = new System.Drawing.Size(92, 17);
             this.chkHighContrastRunes.TabIndex = 25;
             this.chkHighContrastRunes.Text = "High contrast";
             this.chkHighContrastRunes.UseVisualStyleBackColor = true;
@@ -606,7 +556,7 @@
             this.chkDisplayRunes.AutoSize = true;
             this.chkDisplayRunes.Location = new System.Drawing.Point(14, 303);
             this.chkDisplayRunes.Name = "chkDisplayRunes";
-            this.chkDisplayRunes.Size = new System.Drawing.Size(57, 17);
+            this.chkDisplayRunes.Size = new System.Drawing.Size(58, 17);
             this.chkDisplayRunes.TabIndex = 26;
             this.chkDisplayRunes.Text = "Runes";
             this.chkDisplayRunes.UseVisualStyleBackColor = true;
@@ -758,7 +708,7 @@
             this.chkDisplayDifficultyPercents.ForeColor = System.Drawing.SystemColors.ControlText;
             this.chkDisplayDifficultyPercents.Location = new System.Drawing.Point(14, 244);
             this.chkDisplayDifficultyPercents.Name = "chkDisplayDifficultyPercents";
-            this.chkDisplayDifficultyPercents.Size = new System.Drawing.Size(77, 17);
+            this.chkDisplayDifficultyPercents.Size = new System.Drawing.Size(83, 17);
             this.chkDisplayDifficultyPercents.TabIndex = 5;
             this.chkDisplayDifficultyPercents.Text = "Difficulty %";
             this.chkDisplayDifficultyPercents.UseVisualStyleBackColor = true;
@@ -769,7 +719,7 @@
             this.chkDisplayAdvancedStats.ForeColor = System.Drawing.SystemColors.ControlText;
             this.chkDisplayAdvancedStats.Location = new System.Drawing.Point(14, 120);
             this.chkDisplayAdvancedStats.Name = "chkDisplayAdvancedStats";
-            this.chkDisplayAdvancedStats.Size = new System.Drawing.Size(105, 17);
+            this.chkDisplayAdvancedStats.Size = new System.Drawing.Size(112, 17);
             this.chkDisplayAdvancedStats.TabIndex = 5;
             this.chkDisplayAdvancedStats.Text = "Fcr, Frw, Fhr, Ias";
             this.chkDisplayAdvancedStats.UseVisualStyleBackColor = true;
@@ -779,7 +729,7 @@
             this.chkDisplayLevel.AutoSize = true;
             this.chkDisplayLevel.Location = new System.Drawing.Point(14, 182);
             this.chkDisplayLevel.Name = "chkDisplayLevel";
-            this.chkDisplayLevel.Size = new System.Drawing.Size(52, 17);
+            this.chkDisplayLevel.Size = new System.Drawing.Size(53, 17);
             this.chkDisplayLevel.TabIndex = 4;
             this.chkDisplayLevel.Text = "Level";
             this.chkDisplayLevel.UseVisualStyleBackColor = true;
@@ -789,7 +739,7 @@
             this.chkDisplayGold.AutoSize = true;
             this.chkDisplayGold.Location = new System.Drawing.Point(14, 57);
             this.chkDisplayGold.Name = "chkDisplayGold";
-            this.chkDisplayGold.Size = new System.Drawing.Size(48, 17);
+            this.chkDisplayGold.Size = new System.Drawing.Size(50, 17);
             this.chkDisplayGold.TabIndex = 4;
             this.chkDisplayGold.Text = "Gold";
             this.chkDisplayGold.UseVisualStyleBackColor = true;
@@ -799,7 +749,7 @@
             this.chkDisplayResistances.AutoSize = true;
             this.chkDisplayResistances.Location = new System.Drawing.Point(14, 213);
             this.chkDisplayResistances.Name = "chkDisplayResistances";
-            this.chkDisplayResistances.Size = new System.Drawing.Size(84, 17);
+            this.chkDisplayResistances.Size = new System.Drawing.Size(88, 17);
             this.chkDisplayResistances.TabIndex = 3;
             this.chkDisplayResistances.Text = "Resistances";
             this.chkDisplayResistances.UseVisualStyleBackColor = true;
@@ -809,7 +759,7 @@
             this.chkDisplayBaseStats.AutoSize = true;
             this.chkDisplayBaseStats.Location = new System.Drawing.Point(14, 89);
             this.chkDisplayBaseStats.Name = "chkDisplayBaseStats";
-            this.chkDisplayBaseStats.Size = new System.Drawing.Size(107, 17);
+            this.chkDisplayBaseStats.Size = new System.Drawing.Size(110, 17);
             this.chkDisplayBaseStats.TabIndex = 2;
             this.chkDisplayBaseStats.Text = "Str, Dex, Vit, Ene";
             this.chkDisplayBaseStats.UseVisualStyleBackColor = true;
@@ -819,7 +769,7 @@
             this.chkDisplayDeathCounter.AutoSize = true;
             this.chkDisplayDeathCounter.Location = new System.Drawing.Point(14, 151);
             this.chkDisplayDeathCounter.Name = "chkDisplayDeathCounter";
-            this.chkDisplayDeathCounter.Size = new System.Drawing.Size(60, 17);
+            this.chkDisplayDeathCounter.Size = new System.Drawing.Size(61, 17);
             this.chkDisplayDeathCounter.TabIndex = 1;
             this.chkDisplayDeathCounter.Text = "Deaths";
             this.chkDisplayDeathCounter.UseVisualStyleBackColor = true;
@@ -829,66 +779,35 @@
             this.chkDisplayName.AutoSize = true;
             this.chkDisplayName.Location = new System.Drawing.Point(14, 24);
             this.chkDisplayName.Name = "chkDisplayName";
-            this.chkDisplayName.Size = new System.Drawing.Size(54, 17);
+            this.chkDisplayName.Size = new System.Drawing.Size(55, 17);
             this.chkDisplayName.TabIndex = 0;
             this.chkDisplayName.Text = "Name";
             this.chkDisplayName.UseVisualStyleBackColor = true;
             // 
             // tabPageSettingsRunes
             // 
-            this.tabPageSettingsRunes.Controls.Add(this.tableLayoutPanel1);
+            this.tabPageSettingsRunes.Controls.Add(this.runeSettingsPage);
             this.tabPageSettingsRunes.Location = new System.Drawing.Point(4, 22);
             this.tabPageSettingsRunes.Name = "tabPageSettingsRunes";
-            this.tabPageSettingsRunes.Size = new System.Drawing.Size(497, 439);
+            this.tabPageSettingsRunes.Size = new System.Drawing.Size(497, 440);
             this.tabPageSettingsRunes.TabIndex = 2;
             this.tabPageSettingsRunes.Text = "Runes";
             this.tabPageSettingsRunes.UseVisualStyleBackColor = true;
             // 
-            // tableLayoutPanel1
+            // runeSettingsPage
             // 
-            this.tableLayoutPanel1.ColumnCount = 1;
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.Controls.Add(this.panel2, 0, 1);
-            this.tableLayoutPanel1.Controls.Add(this.RuneDisplayPanel, 0, 0);
-            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
-            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(0);
-            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            this.tableLayoutPanel1.RowCount = 2;
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 32F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(497, 439);
-            this.tableLayoutPanel1.TabIndex = 5;
-            // 
-            // panel2
-            // 
-            this.panel2.Controls.Add(this.RuneComboBox);
-            this.panel2.Controls.Add(this.btnAddRuneWord);
-            this.panel2.Controls.Add(this.AddRuneButton);
-            this.panel2.Controls.Add(this.cbRuneWord);
-            this.panel2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panel2.Location = new System.Drawing.Point(0, 407);
-            this.panel2.Margin = new System.Windows.Forms.Padding(0);
-            this.panel2.Name = "panel2";
-            this.panel2.Size = new System.Drawing.Size(497, 32);
-            this.panel2.TabIndex = 6;
-            // 
-            // RuneDisplayPanel
-            // 
-            this.RuneDisplayPanel.AutoScroll = true;
-            this.RuneDisplayPanel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.RuneDisplayPanel.Location = new System.Drawing.Point(0, 0);
-            this.RuneDisplayPanel.Margin = new System.Windows.Forms.Padding(0);
-            this.RuneDisplayPanel.Name = "RuneDisplayPanel";
-            this.RuneDisplayPanel.Size = new System.Drawing.Size(497, 407);
-            this.RuneDisplayPanel.TabIndex = 7;
+            this.runeSettingsPage.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.runeSettingsPage.Location = new System.Drawing.Point(0, 0);
+            this.runeSettingsPage.Name = "runeSettingsPage";
+            this.runeSettingsPage.Size = new System.Drawing.Size(497, 440);
+            this.runeSettingsPage.TabIndex = 0;
             // 
             // tabPageSettingsAutosplit
             // 
             this.tabPageSettingsAutosplit.Controls.Add(this.AutoSplitLayout);
             this.tabPageSettingsAutosplit.Location = new System.Drawing.Point(4, 22);
             this.tabPageSettingsAutosplit.Name = "tabPageSettingsAutosplit";
-            this.tabPageSettingsAutosplit.Size = new System.Drawing.Size(497, 439);
+            this.tabPageSettingsAutosplit.Size = new System.Drawing.Size(497, 440);
             this.tabPageSettingsAutosplit.TabIndex = 0;
             this.tabPageSettingsAutosplit.Text = "Auto-Split";
             this.tabPageSettingsAutosplit.UseVisualStyleBackColor = true;
@@ -900,7 +819,7 @@
             this.tabPageSettingsMisc.Location = new System.Drawing.Point(4, 22);
             this.tabPageSettingsMisc.Name = "tabPageSettingsMisc";
             this.tabPageSettingsMisc.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPageSettingsMisc.Size = new System.Drawing.Size(497, 439);
+            this.tabPageSettingsMisc.Size = new System.Drawing.Size(497, 440);
             this.tabPageSettingsMisc.TabIndex = 3;
             this.tabPageSettingsMisc.Text = "Misc";
             this.tabPageSettingsMisc.UseVisualStyleBackColor = true;
@@ -921,7 +840,7 @@
             this.CreateFilesCheckBox.AutoSize = true;
             this.CreateFilesCheckBox.Location = new System.Drawing.Point(10, 19);
             this.CreateFilesCheckBox.Name = "CreateFilesCheckBox";
-            this.CreateFilesCheckBox.Size = new System.Drawing.Size(78, 17);
+            this.CreateFilesCheckBox.Size = new System.Drawing.Size(83, 17);
             this.CreateFilesCheckBox.TabIndex = 8;
             this.CreateFilesCheckBox.Text = "Create files";
             this.CreateFilesCheckBox.UseVisualStyleBackColor = true;
@@ -955,7 +874,7 @@
             this.CheckUpdatesCheckBox.AutoSize = true;
             this.CheckUpdatesCheckBox.Location = new System.Drawing.Point(10, 19);
             this.CheckUpdatesCheckBox.Name = "CheckUpdatesCheckBox";
-            this.CheckUpdatesCheckBox.Size = new System.Drawing.Size(148, 17);
+            this.CheckUpdatesCheckBox.Size = new System.Drawing.Size(153, 17);
             this.CheckUpdatesCheckBox.TabIndex = 1;
             this.CheckUpdatesCheckBox.Text = "Check for updates at start";
             this.CheckUpdatesCheckBox.UseVisualStyleBackColor = true;
@@ -973,7 +892,7 @@
             this.mainPanel.RowCount = 2;
             this.mainPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.mainPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 32F));
-            this.mainPanel.Size = new System.Drawing.Size(686, 503);
+            this.mainPanel.Size = new System.Drawing.Size(686, 504);
             this.mainPanel.TabIndex = 23;
             // 
             // panel1
@@ -982,7 +901,7 @@
             this.panel1.Controls.Add(this.btnUndo);
             this.panel1.Controls.Add(this.btnSave);
             this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panel1.Location = new System.Drawing.Point(0, 471);
+            this.panel1.Location = new System.Drawing.Point(0, 472);
             this.panel1.Margin = new System.Windows.Forms.Padding(0);
             this.panel1.Name = "panel1";
             this.panel1.Size = new System.Drawing.Size(686, 32);
@@ -1025,7 +944,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(686, 503);
+            this.ClientSize = new System.Drawing.Size(686, 504);
             this.Controls.Add(this.mainPanel);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MinimumSize = new System.Drawing.Size(702, 542);
@@ -1052,8 +971,6 @@
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
             this.tabPageSettingsRunes.ResumeLayout(false);
-            this.tableLayoutPanel1.ResumeLayout(false);
-            this.panel2.ResumeLayout(false);
             this.tabPageSettingsAutosplit.ResumeLayout(false);
             this.tabPageSettingsMisc.ResumeLayout(false);
             this.DataGroup.ResumeLayout(false);
@@ -1075,8 +992,6 @@
         private System.Windows.Forms.CheckBox EnableAutosplitCheckBox;
         private System.Windows.Forms.Label AutoSplitHotkeyLabel;
         private System.Windows.Forms.Button AutoSplitTestHotkeyButton;
-        private System.Windows.Forms.Button AddRuneButton;
-        private System.Windows.Forms.ComboBox RuneComboBox;
         private System.Windows.Forms.TableLayoutPanel VerticalSplitContainer;
         private System.Windows.Forms.TableLayoutPanel HorizontalSplitContainer;
         private System.Windows.Forms.TableLayoutPanel AutoSplitLayout;
@@ -1098,8 +1013,6 @@
         private System.Windows.Forms.Button btnUndo;
         private System.Windows.Forms.Button btnSave;
         private System.Windows.Forms.CheckBox chkDisplayDifficultyPercents;
-        private System.Windows.Forms.Button btnAddRuneWord;
-        private System.Windows.Forms.ComboBox cbRuneWord;
         private System.Windows.Forms.Button btnSaveAs;
         private System.Windows.Forms.GroupBox grpConfigFiles;
         private System.Windows.Forms.ListBox lstConfigFiles;
@@ -1112,15 +1025,12 @@
         private System.Windows.Forms.TabPage tabPageSettingsLayout;
         private System.Windows.Forms.TabPage tabPageSettingsAutosplit;
         private System.Windows.Forms.TabPage tabPageSettingsRunes;
-        private System.Windows.Forms.Panel panel2;
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.TabPage tabPageSettingsMisc;
         private System.Windows.Forms.GroupBox DataGroup;
         private System.Windows.Forms.CheckBox CreateFilesCheckBox;
         private System.Windows.Forms.GroupBox UpdateGroup;
         private System.Windows.Forms.Button CheckUpdatesButton;
         private System.Windows.Forms.CheckBox CheckUpdatesCheckBox;
-        private System.Windows.Forms.FlowLayoutPanel RuneDisplayPanel;
         private System.Windows.Forms.Button btnSetLevelColor;
         private System.Windows.Forms.Button btnSetFireResColor;
         private System.Windows.Forms.Button btnSetDeathsColor;
@@ -1145,5 +1055,6 @@
         private System.Windows.Forms.CheckBox chkHighContrastRunes;
         private System.Windows.Forms.CheckBox chkDisplayRunes;
         private System.Windows.Forms.CheckBox chkShowRealValues;
+        private Controls.RuneSettingsPage runeSettingsPage;
     }
 }


### PR DESCRIPTION
- Reworks the rune settings tab page to support configuration per
character and difficulty setting.
- Target difficulty settings is set in MainWindow context menu.
- Old rune settings are automatically converted to the new format.

When the rune list is loaded it considers them in the following order:
- Class and Difficulty both set
- Class set
- Difficulty set
- Default fallback