### PR TITLE
Fix missing Request/Reponse classes

### DIFF
--- a/src/DiabloInterface.Server/Request.cs
+++ b/src/DiabloInterface.Server/Request.cs
@@ -1,0 +1,10 @@
+using Newtonsoft.Json.Linq;
+
+namespace Zutatensuppe.DiabloInterface.Server
+{
+    public class Request
+    {
+        public string Resource { get; set; }
+        public JToken Payload { get; set; }
+    }
+}

--- a/src/DiabloInterface.Server/Response.cs
+++ b/src/DiabloInterface.Server/Response.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+
+namespace Zutatensuppe.DiabloInterface.Server
+{
+    public enum ResponseStatus
+    {
+        NotFound,
+        Error,
+        Success,
+    }
+
+    public class Response
+    {
+        public string Resource { get; set; }
+        public ResponseStatus Status { get; set; }
+        public IEnumerable<string> Errors { get; set; }
+        public object Payload { get; set; }
+    }
+}


### PR DESCRIPTION
Seems like they were never committed after they were renamed in 6e64d3ca4a218f93a5948ee382711b85f181d56a. Feel free to close this and commit your local copies if they are different.