### PR TITLE
Fix incorrect elemental damage string lookups

### DIFF
--- a/src/D2Reader/Readers/StringLookupTable.cs
+++ b/src/D2Reader/Readers/StringLookupTable.cs
@@ -1,4 +1,4 @@
-using Zutatensuppe.D2Reader.Struct;
+﻿using Zutatensuppe.D2Reader.Struct;
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
@@ -13,14 +13,14 @@ namespace Zutatensuppe.D2Reader.Readers
         public const ushort Durability              = 0x0D81; // "Durability:"
         public const ushort Defense                 = 0x0D85; // "Defense:"
         public const ushort DurabilityBetween       = 0x0D87; // "of"
-        public const ushort FireDamageRange         = 0x0E1C;
-        public const ushort FireDamage              = 0x0E1D;
-        public const ushort ColdDamageRange         = 0x0E1E;
-        public const ushort ColdDamage              = 0x0E1F;
-        public const ushort LightningDamageRange    = 0x0E20;
-        public const ushort LightningDamage         = 0x0E21;
-        public const ushort MagicDamageRange        = 0x0E22;
-        public const ushort MagicDamage             = 0x0E23;
+        public const ushort FireDamage              = 0x0E1C;
+        public const ushort FireDamageRange         = 0x0E1D;
+        public const ushort ColdDamage              = 0x0E1E;
+        public const ushort ColdDamageRange         = 0x0E1F;
+        public const ushort LightningDamage         = 0x0E20;
+        public const ushort LightningDamageRange    = 0x0E21;
+        public const ushort MagicDamage             = 0x0E22;
+        public const ushort MagicDamageRange        = 0x0E23;
         public const ushort PoisonOverTimeSame      = 0x0E24;
         public const ushort PoisonOverTime          = 0x0E25;
         public const ushort DamageRange             = 0x0E27;


### PR DESCRIPTION
Turns out the 'lightning damage on SoJ not showing up' thing in #32 was a separate issue from what was fixed in #33 (hence why it didn't throw an error). The offsets for the ranged/absolute string lookups for elemental damage were swapped, so it was returning early in `RangeStatDamage._toString`. Poison was correct, though.