### PR TITLE
Add support for D2SE

### DIFF
--- a/src/D2Reader/ProcessMemoryReader.cs
+++ b/src/D2Reader/ProcessMemoryReader.cs
@@ -1,4 +1,4 @@
-namespace Zutatensuppe.D2Reader
+﻿namespace Zutatensuppe.D2Reader
 {
     using System;
     using System.Collections.Generic;
@@ -85,6 +85,7 @@ namespace Zutatensuppe.D2Reader
         public Dictionary<string, IntPtr> ModuleBaseAddresses { get; }
 
         public string FileVersion { get; }
+        public string ModuleName { get; }
 
         public bool IsValid
         {
@@ -172,6 +173,7 @@ namespace Zutatensuppe.D2Reader
                 foundProcessId
             );
             FileVersion = foundFileVersion;
+            ModuleName = moduleName;
 
             // Make sure we succeeded in opening the handle.
             if (processHandle == IntPtr.Zero) throw new ProcessNotFoundException(processName, moduleName);


### PR DESCRIPTION
This will allow Diablo Interface to work when D2 is launched via D2SE, but there are a few things worth noting:

- The file version of D2SE.exe is empty, so the console will print things like `ERROR [4] D2Reader.D2DataReader - Diablo II Process was found, but the version  is not supported.`
- The game version detection may be somewhat flimsy and might only work correctly for D2SE version 2.2.0 (untested with other versions).

Here's a general overview of the situation with D2SE in case you want to implement this in a different/better way:

- Game.exe is not used at all when launching from D2SE.exe, instead D2SE.exe is both the launcher and a Game.exe replacement
- As far as I can tell, all Game.exe offsets are the same with D2SE.exe, so all that needs to be done is use D2SE.exe *as* Game.exe for the process memory reader.
- D2SE.exe (v2.2.0) stores the Diablo II version that is running in memory at offset `D2SE.exe + 0x1A049`, as a string like `1.13c`, `1.12a`, etc.