### PR TITLE
Add run counter

### DIFF
--- a/src/DiabloInterface.Business/Settings/ApplicationSettings.cs
+++ b/src/DiabloInterface.Business/Settings/ApplicationSettings.cs
@@ -42,12 +42,14 @@ namespace Zutatensuppe.DiabloInterface.Business.Settings
         public bool DisplayLayoutHorizontal { get; set; } = true;
         public bool DisplayRealFrwIas { get; set; } = false;
         public bool DisplayPlayersX { get; set; } = false;
+        public bool DisplayGameCounter { get; set; } = false;
 
         public int VerticalLayoutPadding { get; set; } = 5;
 
         public Color ColorName { get; set; } = Color.RoyalBlue;
         public Color ColorDeaths { get; set; } = Color.Snow;
         public Color ColorPlayersX { get; set; } = Color.Snow;
+        public Color ColorGameCounter { get; set; } = Color.Snow;
         public Color ColorLevel { get; set; } = Color.Snow;
         public Color ColorDifficultyPercentages { get; set; } = Color.Snow;
         public Color ColorGold { get; set; } = Color.Gold;

--- a/src/DiabloInterface/Gui/Controls/AbstractLayout.Designer.cs
+++ b/src/DiabloInterface/Gui/Controls/AbstractLayout.Designer.cs
@@ -86,6 +86,7 @@ namespace Zutatensuppe.DiabloInterface.Gui.Controls
             this.labelNmPerc = new System.Windows.Forms.Label();
             this.labelHellPerc = new System.Windows.Forms.Label();
             this.panelRuneDisplayHorizontal = new System.Windows.Forms.FlowLayoutPanel();
+            this.gameCounterLabel = new System.Windows.Forms.Label();
             this.outerLeftRightPanel.SuspendLayout();
             this.panelDeathsLvl.SuspendLayout();
             this.panelSimpleStats.SuspendLayout();
@@ -148,5 +149,7 @@ namespace Zutatensuppe.DiabloInterface.Gui.Controls
         protected System.Windows.Forms.Label labelHellPerc;
         protected System.Windows.Forms.FlowLayoutPanel panelRuneDisplayHorizontal;
         protected System.Windows.Forms.FlowLayoutPanel panelRuneDisplayVertical;
+        protected System.Windows.Forms.Label gameCounterLabel;
+
     }
 }

--- a/src/DiabloInterface/Gui/Controls/AbstractLayout.Designer.cs
+++ b/src/DiabloInterface/Gui/Controls/AbstractLayout.Designer.cs
@@ -43,7 +43,6 @@ namespace Zutatensuppe.DiabloInterface.Gui.Controls
             this.playersXLabel = new System.Windows.Forms.Label();
             this.panelDeathsLvl = new System.Windows.Forms.TableLayoutPanel();
             this.deathsLabel = new System.Windows.Forms.Label();
-            this.playersXLabel = new System.Windows.Forms.Label();
             this.lvlLabel = new System.Windows.Forms.Label();
             this.panelSimpleStats = new System.Windows.Forms.TableLayoutPanel();
             this.goldLabel = new System.Windows.Forms.Label();

--- a/src/DiabloInterface/Gui/Controls/AbstractLayout.cs
+++ b/src/DiabloInterface/Gui/Controls/AbstractLayout.cs
@@ -117,7 +117,7 @@ namespace Zutatensuppe.DiabloInterface.Gui.Controls
                 return;
             }
 
-            UpdateLabels(e.Character, e.Quests, e.CurrentPlayersX);
+            UpdateLabels(e.Character, e.Quests, e.CurrentPlayersX, e.GameCounter);
             UpdateClassRuneList(e.Character.CharClass);
             UpdateRuneDisplay(e.ItemIds);
         }
@@ -166,13 +166,14 @@ namespace Zutatensuppe.DiabloInterface.Gui.Controls
             deathsLabel.Visible = settings.DisplayDeathCounter;
             lvlLabel.Visible = settings.DisplayLevel;
             playersXLabel.Visible = settings.DisplayPlayersX;
+            gameCounterLabel.Visible = settings.DisplayGameCounter;
         }
 
         abstract protected void ApplyRuneSettings(ApplicationSettings settings);
 
         abstract protected void UpdateLayout(ApplicationSettings settings);
 
-        protected void UpdateLabels(Character player, IList<QuestCollection> quests, int currentPlayersX)
+        protected void UpdateLabels(Character player, IList<QuestCollection> quests, int currentPlayersX, uint gameIndex)
         {
             nameLabel.Text = player.Name;
             lvlLabel.Text = "LVL: " + player.Level;
@@ -209,6 +210,8 @@ namespace Zutatensuppe.DiabloInterface.Gui.Controls
             labelNormPerc.Text = $@"NO: {completions[0]:0%}";
             labelNmPerc.Text = $@"NM: {completions[1]:0%}";
             labelHellPerc.Text = $@"HE: {completions[2]:0%}";
+
+            gameCounterLabel.Text = "Run count: " + gameIndex;
         }
 
         protected void UpdateLabelWidthAlignment(params Label[] labels)

--- a/src/DiabloInterface/Gui/Controls/HorizontalLayout.Designer.cs
+++ b/src/DiabloInterface/Gui/Controls/HorizontalLayout.Designer.cs
@@ -68,6 +68,7 @@ namespace Zutatensuppe.DiabloInterface.Gui.Controls
             this.flowLayoutPanel1.AutoSize = true;
             this.flowLayoutPanel1.Controls.Add(this.nameLabel);
             this.flowLayoutPanel1.Controls.Add(this.playersXLabel);
+            this.flowLayoutPanel1.Controls.Add(this.gameCounterLabel);
             this.flowLayoutPanel1.Controls.Add(this.panelDeathsLvl);
             this.flowLayoutPanel1.Controls.Add(this.panelSimpleStats);
             this.flowLayoutPanel1.Controls.Add(this.panelStats);
@@ -91,6 +92,17 @@ namespace Zutatensuppe.DiabloInterface.Gui.Controls
             this.nameLabel.Size = new System.Drawing.Size(68, 27);
             this.nameLabel.TabIndex = 6;
             this.nameLabel.Text = "Name";
+
+            this.gameCounterLabel.AutoSize = true;
+            this.gameCounterLabel.Font = new System.Drawing.Font("Courier New", 9.75F);
+            this.gameCounterLabel.ForeColor = System.Drawing.Color.White;
+            this.gameCounterLabel.Location = new System.Drawing.Point(3, 0);
+            this.gameCounterLabel.Margin = new System.Windows.Forms.Padding(3, 0, 0, 3);
+            this.gameCounterLabel.Name = "gameCounterLabel";
+            this.gameCounterLabel.Size = new System.Drawing.Size(68, 27);
+            this.gameCounterLabel.TabIndex = 6;
+            this.gameCounterLabel.Text = "Run count: 1";
+
             // 
             // playersXLabel
             // 

--- a/src/DiabloInterface/Gui/Controls/HorizontalLayout.cs
+++ b/src/DiabloInterface/Gui/Controls/HorizontalLayout.cs
@@ -36,6 +36,7 @@ namespace Zutatensuppe.DiabloInterface.Gui.Controls
             {
                 deathsLabel,
                 playersXLabel,
+                gameCounterLabel,
                 goldLabel, lvlLabel,
                 strLabel, dexLabel, vitLabel, eneLabel,
                 frwLabel, fhrLabel, fcrLabel, iasLabel,

--- a/src/DiabloInterface/Gui/Controls/HorizontalLayout.cs
+++ b/src/DiabloInterface/Gui/Controls/HorizontalLayout.cs
@@ -203,6 +203,7 @@ namespace Zutatensuppe.DiabloInterface.Gui.Controls
             deathsLabel.ForeColor = settings.ColorDeaths;
             lvlLabel.ForeColor = settings.ColorLevel;
             playersXLabel.ForeColor = settings.ColorPlayersX;
+            gameCounterLabel.ForeColor = settings.ColorGameCounter;
 
             UpdateLabelColors(settings);
         }

--- a/src/DiabloInterface/Gui/Controls/VerticalLayout.Designer.cs
+++ b/src/DiabloInterface/Gui/Controls/VerticalLayout.Designer.cs
@@ -595,6 +595,16 @@ namespace Zutatensuppe.DiabloInterface.Gui.Controls
             this.playersXLabel.Size = new System.Drawing.Size(68, 27);
             this.playersXLabel.TabIndex = 6;
             this.playersXLabel.Text = "/players X";
+
+            this.gameCounterLabel.AutoSize = true;
+            this.gameCounterLabel.Font = new System.Drawing.Font("Courier New", 9.75F);
+            this.gameCounterLabel.ForeColor = System.Drawing.Color.White;
+            this.gameCounterLabel.Location = new System.Drawing.Point(3, 0);
+            this.gameCounterLabel.Margin = new System.Windows.Forms.Padding(3, 0, 0, 3);
+            this.gameCounterLabel.Name = "gameCounterLabel";
+            this.gameCounterLabel.Size = new System.Drawing.Size(68, 27);
+            this.gameCounterLabel.TabIndex = 6;
+            this.gameCounterLabel.Text = "Run count: 1";
             // 
             // flowLayoutPanel1
             // 
@@ -602,6 +612,7 @@ namespace Zutatensuppe.DiabloInterface.Gui.Controls
             this.flowLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.flowLayoutPanel1.Controls.Add(this.nameLabel);
             this.flowLayoutPanel1.Controls.Add(this.playersXLabel);
+            this.flowLayoutPanel1.Controls.Add(this.gameCounterLabel);
             this.flowLayoutPanel1.Controls.Add(this.outerLeftRightPanel);
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
             this.flowLayoutPanel1.Location = new System.Drawing.Point(0, 0);

--- a/src/DiabloInterface/Gui/Controls/VerticalLayout.cs
+++ b/src/DiabloInterface/Gui/Controls/VerticalLayout.cs
@@ -31,6 +31,7 @@ namespace Zutatensuppe.DiabloInterface.Gui.Controls
             {
                 deathsLabel,
                 playersXLabel,
+                gameCounterLabel,
                 goldLabel, lvlLabel,
                 strLabel, dexLabel, vitLabel, eneLabel,
                 frwLabel, fhrLabel, fcrLabel, iasLabel,

--- a/src/DiabloInterface/Gui/Controls/VerticalLayout.cs
+++ b/src/DiabloInterface/Gui/Controls/VerticalLayout.cs
@@ -144,6 +144,7 @@ namespace Zutatensuppe.DiabloInterface.Gui.Controls
             deathsLabel.ForeColor = settings.ColorDeaths;
             lvlLabel.ForeColor = settings.ColorLevel;
             playersXLabel.ForeColor = settings.ColorPlayersX;
+            gameCounterLabel.ForeColor = settings.ColorGameCounter;
 
             UpdateLabelColors(settings);
         }

--- a/src/DiabloInterface/Gui/SettingsWindow.Designer.cs
+++ b/src/DiabloInterface/Gui/SettingsWindow.Designer.cs
@@ -68,7 +68,9 @@ namespace Zutatensuppe.DiabloInterface.Gui
             this.comboBoxLayout = new System.Windows.Forms.ComboBox();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.btnSetPlayersXColor = new System.Windows.Forms.Button();
+            this.btnSetGameCounterColor = new System.Windows.Forms.Button();
             this.chkShowPlayersX = new System.Windows.Forms.CheckBox();
+            this.chkShowGameCounter = new System.Windows.Forms.CheckBox();
             this.chkShowRealValues = new System.Windows.Forms.CheckBox();
             this.chkHighContrastRunes = new System.Windows.Forms.CheckBox();
             this.chkDisplayRunes = new System.Windows.Forms.CheckBox();
@@ -536,7 +538,10 @@ namespace Zutatensuppe.DiabloInterface.Gui
             // groupBox1
             // 
             this.groupBox1.Controls.Add(this.btnSetPlayersXColor);
+            this.groupBox1.Controls.Add(this.btnSetGameCounterColor);
             this.groupBox1.Controls.Add(this.chkShowPlayersX);
+            this.groupBox1.Controls.Add(this.chkShowGameCounter);
+
             this.groupBox1.Controls.Add(this.chkShowRealValues);
             this.groupBox1.Controls.Add(this.chkHighContrastRunes);
             this.groupBox1.Controls.Add(this.chkDisplayRunes);
@@ -589,9 +594,29 @@ namespace Zutatensuppe.DiabloInterface.Gui
             this.chkShowPlayersX.Margin = new System.Windows.Forms.Padding(4);
             this.chkShowPlayersX.Name = "chkShowPlayersX";
             this.chkShowPlayersX.Size = new System.Drawing.Size(93, 21);
-            this.chkShowPlayersX.TabIndex = 28;
+            //this.chkShowPlayersX.TabIndex = 28;
             this.chkShowPlayersX.Text = "/players X";
             this.chkShowPlayersX.UseVisualStyleBackColor = true;
+
+
+            this.btnSetGameCounterColor.Location = new System.Drawing.Point(169, 376);
+            this.btnSetGameCounterColor.Margin = new System.Windows.Forms.Padding(0);
+            this.btnSetGameCounterColor.Name = "btnSetGameCounterColor";
+            this.btnSetGameCounterColor.Size = new System.Drawing.Size(99, 31);
+           // this.btnSetGameCounterColor.TabIndex = 29;
+            this.btnSetGameCounterColor.Text = "Color";
+            this.btnSetGameCounterColor.UseVisualStyleBackColor = true;
+            this.btnSetGameCounterColor.Click += new System.EventHandler(this.btnSetColorGameCounter_Click);
+
+            this.chkShowGameCounter.AutoSize = true;
+            this.chkShowGameCounter.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.chkShowGameCounter.Location = new System.Drawing.Point(19, 382);
+            this.chkShowGameCounter.Margin = new System.Windows.Forms.Padding(4);
+            this.chkShowGameCounter.Name = "chkShowGameCounter";
+            this.chkShowGameCounter.Size = new System.Drawing.Size(93, 21);
+            this.chkShowGameCounter.TabIndex = 28;
+            this.chkShowGameCounter.Text = "Run count";
+            this.chkShowGameCounter.UseVisualStyleBackColor = true;
             // 
             // chkShowRealValues
             // 
@@ -628,10 +653,10 @@ namespace Zutatensuppe.DiabloInterface.Gui
             // 
             // btnSetBackgroundColor
             // 
-            this.btnSetBackgroundColor.Location = new System.Drawing.Point(169, 376);
+            this.btnSetBackgroundColor.Location = new System.Drawing.Point(276, 376);
             this.btnSetBackgroundColor.Margin = new System.Windows.Forms.Padding(4);
             this.btnSetBackgroundColor.Name = "btnSetBackgroundColor";
-            this.btnSetBackgroundColor.Size = new System.Drawing.Size(205, 28);
+            this.btnSetBackgroundColor.Size = new System.Drawing.Size(150, 28);
             this.btnSetBackgroundColor.TabIndex = 23;
             this.btnSetBackgroundColor.Text = "Background color";
             this.btnSetBackgroundColor.UseVisualStyleBackColor = true;
@@ -639,10 +664,10 @@ namespace Zutatensuppe.DiabloInterface.Gui
             // 
             // button1
             // 
-            this.button1.Location = new System.Drawing.Point(383, 376);
+            this.button1.Location = new System.Drawing.Point(432, 376);
             this.button1.Margin = new System.Windows.Forms.Padding(4);
             this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(205, 28);
+            this.button1.Size = new System.Drawing.Size(150, 28);
             this.button1.TabIndex = 8;
             this.button1.Text = "Reset to default colors";
             this.button1.UseVisualStyleBackColor = true;
@@ -1176,7 +1201,9 @@ namespace Zutatensuppe.DiabloInterface.Gui
         private System.Windows.Forms.CheckBox chkShowRealValues;
         private Controls.RuneSettingsPage runeSettingsPage;
         private System.Windows.Forms.Button btnSetPlayersXColor;
+        private System.Windows.Forms.Button btnSetGameCounterColor;
         private System.Windows.Forms.CheckBox chkShowPlayersX;
+        private System.Windows.Forms.CheckBox chkShowGameCounter;
         private System.Windows.Forms.GroupBox groupBoxPipeServer;
         private System.Windows.Forms.TextBox textBoxPipeName;
         private System.Windows.Forms.Label labelPipeName;

--- a/src/DiabloInterface/Gui/SettingsWindow.cs
+++ b/src/DiabloInterface/Gui/SettingsWindow.cs
@@ -86,6 +86,7 @@ namespace Zutatensuppe.DiabloInterface.Gui
                     || settings.VerticalLayoutPadding != (int)numericUpDownPaddingInVerticalLayout.Value
                     || settings.DisplayRealFrwIas != chkShowRealValues.Checked
                     || settings.DisplayPlayersX != chkShowPlayersX.Checked
+                    || settings.DisplayGameCounter != chkShowGameCounter.Checked
 
                     || btnSetNameColor.ForeColor != settings.ColorName
                     || btnSetDeathsColor.ForeColor != settings.ColorDeaths
@@ -99,6 +100,7 @@ namespace Zutatensuppe.DiabloInterface.Gui
                     || btnSetLightningResColor.ForeColor != settings.ColorLightningRes
                     || btnSetPoisonResColor.ForeColor != settings.ColorPoisonRes
                     || btnSetPlayersXColor.ForeColor != settings.ColorPlayersX
+                    || btnSetGameCounterColor.ForeColor != settings.ColorGameCounter
 
                     || btnSetBackgroundColor.BackColor != settings.ColorBackground;
             }
@@ -196,6 +198,7 @@ namespace Zutatensuppe.DiabloInterface.Gui
             comboBoxLayout.SelectedIndex = settings.DisplayLayoutHorizontal ? 0 : 1;
             chkShowRealValues.Checked = settings.DisplayRealFrwIas;
             chkShowPlayersX.Checked = settings.DisplayPlayersX;
+            chkShowGameCounter.Checked = settings.DisplayGameCounter;
 
             SetBackgroundColor(settings.ColorBackground);
 
@@ -211,6 +214,7 @@ namespace Zutatensuppe.DiabloInterface.Gui
             btnSetLightningResColor.ForeColor = settings.ColorLightningRes;
             btnSetPoisonResColor.ForeColor = settings.ColorPoisonRes;
             btnSetPlayersXColor.ForeColor = settings.ColorPlayersX;
+            btnSetGameCounterColor.ForeColor = settings.ColorGameCounter;
         }
 
         void MarkClean()
@@ -258,6 +262,7 @@ namespace Zutatensuppe.DiabloInterface.Gui
             settings.DisplayDifficultyPercentages = chkDisplayDifficultyPercents.Checked;
             settings.DisplayRealFrwIas = chkShowRealValues.Checked;
             settings.DisplayPlayersX = chkShowPlayersX.Checked;
+            settings.DisplayGameCounter = chkShowGameCounter.Checked;
 
             settings.DisplayRunes = chkDisplayRunes.Checked;
             settings.DisplayRunesHorizontal = comboBoxRunesOrientation.SelectedIndex == 0;
@@ -276,6 +281,7 @@ namespace Zutatensuppe.DiabloInterface.Gui
             settings.ColorLightningRes = btnSetLightningResColor.ForeColor;
             settings.ColorPoisonRes = btnSetPoisonResColor.ForeColor;
             settings.ColorPlayersX = btnSetPlayersXColor.ForeColor;
+            settings.ColorGameCounter = btnSetGameCounterColor.ForeColor;
 
             settings.ColorBackground = btnSetBackgroundColor.BackColor;
 
@@ -529,6 +535,7 @@ namespace Zutatensuppe.DiabloInterface.Gui
             btnSetLightningResColor.BackColor = c;
             btnSetPoisonResColor.BackColor = c;
             btnSetPlayersXColor.BackColor = c;
+            btnSetGameCounterColor.BackColor = c;
         }
 
         private void btnSetNameColor_Click(object sender, EventArgs e)
@@ -591,6 +598,11 @@ namespace Zutatensuppe.DiabloInterface.Gui
             SelectColor(sender);
         }
 
+        private void btnSetColorGameCounter_Click(object sender, EventArgs e)
+        {
+            SelectColor(sender);
+        }
+
         private void resetColorsButton(object sender, EventArgs e)
         {
             btnSetNameColor.ForeColor = Color.RoyalBlue;
@@ -605,6 +617,7 @@ namespace Zutatensuppe.DiabloInterface.Gui
             btnSetLightningResColor.ForeColor = Color.Yellow;
             btnSetPoisonResColor.ForeColor = Color.YellowGreen;
             btnSetPlayersXColor.ForeColor = Color.Snow;
+            btnSetGameCounterColor.ForeColor = Color.Snow;
             SetBackgroundColor(Color.Black);
         }
 


### PR DESCRIPTION
This pull request adds a run counter to the display. It is calculated using the existing gameId from D2DataReader so it should work across versions.  I have tested on 1.13d and 1.14.

It adds new settings for enabling/disabling the display. They are as close to the existing settings as possible. I tried to move things as little as possible.

There's another PR on top of this one that adds a global hotkey for resetting the run counter but this seems like a good split to start with.