### PR TITLE
Fix #72 (exception with fog.dll not loaded when only d2se is launched)

### DIFF
--- a/src/D2Reader/D2DataReader.cs
+++ b/src/D2Reader/D2DataReader.cs
@@ -156,6 +156,10 @@ namespace Zutatensuppe.D2Reader
                 {
                     CleanUpDataReaders();
                 }
+                catch (ModuleNotLoadedException)
+                {
+                    CleanUpDataReaders();
+                }
                 if (reader != null)
                 {
                     break;


### PR DESCRIPTION
catching exception, because we just want to detect which version of d2 is running. if fog is not loaded, then it is just a version we don't know.

also catching the module not loaded exceptions in general in the reader, same as process not found 