### PR TITLE
dont exclude secondary body slots from equipped items list

### DIFF
--- a/src/D2Reader/Struct/Item/D2ItemData.cs
+++ b/src/D2Reader/Struct/Item/D2ItemData.cs
@@ -99,10 +99,7 @@ namespace Zutatensuppe.D2Reader.Struct.Item
 
         internal bool IsEquipped()
         {
-            return InvPage == InventoryPage.Equipped
-                // not handled as equipped if in secondary weapon/shield slot
-                && BodyLoc != BodyLocation.SecondaryLeft
-                && BodyLoc != BodyLocation.SecondaryRight;
+            return InvPage == InventoryPage.Equipped;
         }
 
         internal bool IsEquippedInSlot(BodyLocation loc)


### PR DESCRIPTION
nowhere else used, so allowing more data be handled as 'equipped' than before is ok