### PR TITLE
add support for D2 HD patch (D2Loader-high.exe)

### DIFF
--- a/src/D2Reader/GameMemoryTableFactory.cs
+++ b/src/D2Reader/GameMemoryTableFactory.cs
@@ -57,6 +57,7 @@ namespace Zutatensuppe.D2Reader
                 case "1.13c":
                 case "v 1.13c":
                 case "1, 0, 13, 60":
+                case "1, 0, 0, 0": // D2Loader-high.exe
                     return CreateMemoryTableForVersion113C(moduleBaseAddresses);
                 default:
                     throw new GameVersionUnsupportedException(gameVersion);
@@ -165,7 +166,6 @@ namespace Zutatensuppe.D2Reader
         private GameMemoryTable CreateMemoryTableForVersion113D(Dictionary<string, IntPtr> moduleBaseAddresses)
         {
             IntPtr d2CommonAddress = GetModuleAddress("D2Common.dll", moduleBaseAddresses);
-            IntPtr d2LaunchAddress = GetModuleAddress("D2Launch.dll", moduleBaseAddresses);
             IntPtr d2LangAddress = GetModuleAddress("D2Lang.dll", moduleBaseAddresses);
             IntPtr d2NetAddress = GetModuleAddress("D2Net.dll", moduleBaseAddresses);
             IntPtr d2GameAddress = GetModuleAddress("D2Game.dll", moduleBaseAddresses);
@@ -205,7 +205,6 @@ namespace Zutatensuppe.D2Reader
         private GameMemoryTable CreateMemoryTableForVersion113C(Dictionary<string, IntPtr> moduleBaseAddresses)
         {
             IntPtr d2CommonAddress = GetModuleAddress("D2Common.dll", moduleBaseAddresses);
-            IntPtr d2LaunchAddress = GetModuleAddress("D2Launch.dll", moduleBaseAddresses);
             IntPtr d2LangAddress = GetModuleAddress("D2Lang.dll", moduleBaseAddresses);
             IntPtr d2NetAddress = GetModuleAddress("D2Net.dll", moduleBaseAddresses);
             IntPtr d2GameAddress = GetModuleAddress("D2Game.dll", moduleBaseAddresses);

--- a/src/DiabloInterface.Lib/ApplicationConfig.cs
+++ b/src/DiabloInterface.Lib/ApplicationConfig.cs
@@ -86,14 +86,21 @@ namespace Zutatensuppe.DiabloInterface
             new ProcessDescription{
                 ModuleName = "Game.exe",
                 ProcessName = "game",
-                SubModules = new string[] { "D2Common.dll", "D2Launch.dll", "D2Lang.dll", "D2Net.dll", "D2Game.dll", "D2Client.dll" }
+                SubModules = new string[] { "D2Common.dll", "D2Lang.dll", "D2Net.dll", "D2Game.dll", "D2Client.dll" }
             },
             // D2SE
             new ProcessDescription{
                 ModuleName = "D2SE.exe",
                 ProcessName = "d2se",
-                SubModules = new string[] { "D2Common.dll", "D2Launch.dll", "D2Lang.dll", "D2Net.dll", "D2Game.dll", "D2Client.dll", "Fog.dll" }
+                SubModules = new string[] { "D2Common.dll", "D2Lang.dll", "D2Net.dll", "D2Game.dll", "D2Client.dll", "Fog.dll" }
             },
+            // D2Loader-high
+            new ProcessDescription
+            {
+                ModuleName = "D2Loader-high.exe",
+                ProcessName = "D2Loader-high",
+                SubModules = new string[] { "D2Common.dll", "D2Lang.dll", "D2Net.dll", "D2Game.dll", "D2Client.dll" }
+            }
         };
     }
 }


### PR DESCRIPTION
resolves #45 
note: doesnt make the process name configurable in gui, but adds support for the hd patch by default. previously didnt work because of version reported by that program was not one of the ones we checked